### PR TITLE
Fix a bunch of linter errors

### DIFF
--- a/dustmaker/BitReader.py
+++ b/dustmaker/BitReader.py
@@ -1,74 +1,74 @@
 class BitReader:
-  """ Allows integers to be read in little endian byte
-      order from a sequence of bytes.
-  """
-
-  def __init__(self, data):
-    """ Create a new BitReader using data.
-
-        data -- An indexable list of bytes.
+    """ Allows integers to be read in little endian byte
+        order from a sequence of bytes.
     """
-    self.pos = 0
-    self.data = data
 
-  def read(self, bits, signed = False):
-    """ Reads the next `bits` bits into an integer in little endian order.
+    def __init__(self, data):
+        """ Create a new BitReader using data.
 
-        bits -- The number of bits to read.
-        signed -- Indicates if the MSB is a sign bit.
-    """
-    result = 0
+            data -- An indexable list of bytes.
+        """
+        self.pos = 0
+        self.data = data
 
-    ind = self.pos >> 3
-    off = self.pos & 0x7
-    if off != 0:
-      result = self.data[ind] >> off
-      ind += 1
+    def read(self, bits, signed=False):
+        """ Reads the next `bits` bits into an integer in little endian order.
 
-    shift = (8 - off) & 0x7
-    while shift < bits:
-      result |= self.data[ind] << shift
-      ind += 1
-      shift += 8
+            bits -- The number of bits to read.
+            signed -- Indicates if the MSB is a sign bit.
+        """
+        result = 0
 
-    result &= (1 << bits) - 1
-    if signed and (result & (1 << bits - 1)) != 0:
-      result -= 1 << bits
-    self.pos += bits
+        ind = self.pos >> 3
+        off = self.pos & 0x7
+        if off != 0:
+            result = self.data[ind] >> off
+            ind += 1
 
-    return result
+        shift = (8 - off) & 0x7
+        while shift < bits:
+            result |= self.data[ind] << shift
+            ind += 1
+            shift += 8
 
-  def align(self, size = 8):
-    """ Aligns the bit stream to a given multiple of bits.
-        Default alignment is 8-bit alignment.
+        result &= (1 << bits) - 1
+        if signed and (result & (1 << bits - 1)) != 0:
+            result -= 1 << bits
+        self.pos += bits
 
-        size -- The desired bit alignment.
-    """
-    self.pos += (size - self.pos % size) % size
+        return result
 
-  def skip(self, bits):
-    """ Skips `bits` bits in the bit stream.
+    def align(self, size=8):
+        """ Aligns the bit stream to a given multiple of bits.
+            Default alignment is 8-bit alignment.
 
-        bits -- the number of bits to skip.
-    """
-    self.pos += bits
+            size -- The desired bit alignment.
+        """
+        self.pos += (size - self.pos % size) % size
 
-  def more(self):
-    """ Returns true if there are more bits to be read. """
-    return self.pos < len(self.data) * 8
+    def skip(self, bits):
+        """ Skips `bits` bits in the bit stream.
 
-  def read_bytes(self, num):
-    """ Returns a bytes object containing the next `num` bytes from the bit
-        stream.
+            bits -- the number of bits to skip.
+        """
+        self.pos += bits
 
-        num -- The number of bytes to extract from the bit stream.
-    """
-    if (self.pos & 7) == 0:
-      result = self.data[self.pos >> 3 : (self.pos >> 3) + num]
-      self.pos += num * 8
-    else:
-      result = bytearray()
-      for i in range(num):
-        result.append(self.read(8))
-      result = bytes(result)
-    return result
+    def more(self):
+        """ Returns true if there are more bits to be read. """
+        return self.pos < len(self.data) * 8
+
+    def read_bytes(self, num):
+        """ Returns a bytes object containing the next `num` bytes from the bit
+            stream.
+
+            num -- The number of bytes to extract from the bit stream.
+        """
+        if (self.pos & 7) == 0:
+            result = self.data[self.pos >> 3: (self.pos >> 3) + num]
+            self.pos += num * 8
+        else:
+            result = bytearray()
+            for i in range(num):
+                result.append(self.read(8))
+            result = bytes(result)
+        return result

--- a/dustmaker/BitReader.py
+++ b/dustmaker/BitReader.py
@@ -67,8 +67,8 @@ class BitReader:
             result = self.data[self.pos >> 3: (self.pos >> 3) + num]
             self.pos += num * 8
         else:
-            result = bytearray()
-            for i in range(num):
-                result.append(self.read(8))
-            result = bytes(result)
+            temp = bytearray()
+            for _ in range(num):
+                temp.append(self.read(8))
+            result = bytes(temp)
         return result

--- a/dustmaker/BitWriter.py
+++ b/dustmaker/BitWriter.py
@@ -1,65 +1,65 @@
 class BitWriter:
-  """ Allows integers to be written in little endian byte
-      order into a bytes object.
-  """
-
-  def __init__(self):
-    """ Create a new empty BitWriter. """
-    self.pos = 0
-    self.data = bytearray()
-
-  def write(self, bits, val):
-    """ Writes `val` as a `bits` bit integer in little endian order to the
-        bit stream.
-
-        bits -- The number of bits in `val`.
-        val -- The value of the integer.
+    """ Allows integers to be written in little endian byte
+        order into a bytes object.
     """
-    if val < 0:
-      val += 1 << bits
 
-    off = self.pos & 0x7
-    self.pos += bits
-    if off != 0:
-      cnt = min(8 - off, bits)
-      self.data[-1] |= (val & ((1 << cnt) - 1)) << off
-      bits -= cnt
-      val = val >> cnt
+    def __init__(self):
+        """ Create a new empty BitWriter. """
+        self.pos = 0
+        self.data = bytearray()
 
-    while bits >= 8:
-      self.data.append(val & 0xFF)
-      val = val >> 8
-      bits -= 8
+    def write(self, bits, val):
+        """ Writes `val` as a `bits` bit integer in little endian order to the
+            bit stream.
 
-    if bits != 0:
-      self.data.append(val & ((1 << bits) - 1))
+            bits -- The number of bits in `val`.
+            val -- The value of the integer.
+        """
+        if val < 0:
+            val += 1 << bits
 
-  def bytes(self):
-    """ Returns a bytes object containing all written data so far. """
-    return bytes(self.data)
+        off = self.pos & 0x7
+        self.pos += bits
+        if off != 0:
+            cnt = min(8 - off, bits)
+            self.data[-1] |= (val & ((1 << cnt) - 1)) << off
+            bits -= cnt
+            val = val >> cnt
 
-  def byte_count(self):
-    """ Returns the number of bytse written so far. """
-    return len(self.data)
+        while bits >= 8:
+            self.data.append(val & 0xFF)
+            val = val >> 8
+            bits -= 8
 
-  def align(self, size = 8):
-    """ Aligns the bit stream to a given multiple of bits.
-        Default alignment is 8-bit alignment.
+        if bits != 0:
+            self.data.append(val & ((1 << bits) - 1))
 
-        size -- The desired bit alignment.
-    """
-    self.pos += (size - self.pos % size) % size
-    while len(self.data) * 8 < self.pos:
-      self.data.append(0)
+    def bytes(self):
+        """ Returns a bytes object containing all written data so far. """
+        return bytes(self.data)
 
-  def write_bytes(self, data):
-    """ Write the bytes given by `data` to the stream.
+    def byte_count(self):
+        """ Returns the number of bytse written so far. """
+        return len(self.data)
 
-        data -- The bytes to write to the stream.
-    """
-    if (self.pos & 7) == 0:
-      self.data += data
-      self.pos += 8 * len(data)
-    else:
-      for x in data:
-        self.write(8, x)
+    def align(self, size=8):
+        """ Aligns the bit stream to a given multiple of bits.
+            Default alignment is 8-bit alignment.
+
+            size -- The desired bit alignment.
+        """
+        self.pos += (size - self.pos % size) % size
+        while len(self.data) * 8 < self.pos:
+            self.data.append(0)
+
+    def write_bytes(self, data):
+        """ Write the bytes given by `data` to the stream.
+
+            data -- The bytes to write to the stream.
+        """
+        if (self.pos & 7) == 0:
+            self.data += data
+            self.pos += 8 * len(data)
+        else:
+            for x in data:
+                self.write(8, x)

--- a/dustmaker/BitWriter.py
+++ b/dustmaker/BitWriter.py
@@ -61,5 +61,5 @@ class BitWriter:
             self.data += data
             self.pos += 8 * len(data)
         else:
-            for x in data:
-                self.write(8, x)
+            for byte in data:
+                self.write(8, byte)

--- a/dustmaker/Entity.py
+++ b/dustmaker/Entity.py
@@ -1,6 +1,6 @@
+import math
 from .Var import Var, VarType
 
-import math
 
 known_types = []
 
@@ -16,11 +16,11 @@ class Entity:
         entity.type = type
         return entity
 
-    def __init__(self, vars={}, rotation=0,
+    def __init__(self, vars=None, rotation=0,
                  layer=18, unk2=1, unk3=1, unk4=1):
         if hasattr(self, "TYPE_IDENTIFIER"):
             self.type = self.TYPE_IDENTIFIER
-        self.vars = vars
+        self.vars = {} if vars is None else vars
         self.rotation = rotation
         self.layer = layer
         self.unk2 = unk2
@@ -49,7 +49,7 @@ class TriggerArea(Entity):
 
     def __init__(self, vars, rotation=0,
                  layer=0, unk2=0, unk3=0, unk4=0):
-        if not 'trigger_area' in vars:
+        if 'trigger_area' not in vars:
             vars['trigger_area'] = Var(VarType.ARRAY, (VarType.VEC2, []))
         super(TriggerArea, self).__init__(
             vars, rotation, layer, unk2, unk3, unk4)
@@ -59,7 +59,7 @@ class TriggerArea(Entity):
 
     def area_position(self, ind, val=None):
         result = self.vars['trigger_area'].value[1][ind].value
-        if not val is None:
+        if val is not None:
             self.vars['trigger_area'].value[1][ind] = Var(VarType.VEC2, val)
         return result
 
@@ -97,7 +97,7 @@ class Trigger(Entity):
 
     def __init__(self, vars, rotation=0,
                  layer=0, unk2=0, unk3=0, unk4=0):
-        if not 'width' in vars:
+        if 'width' not in vars:
             vars['width'] = Var(VarType.UINT, 500)
         super(Trigger, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
 
@@ -113,30 +113,30 @@ class DeathZone(Entity):
 
     def __init__(self, vars, rotation=0,
                  layer=0, unk2=0, unk3=0, unk4=0):
-        if not 'width' in vars:
+        if 'width' not in vars:
             vars['width'] = Var(VarType.INT, 1)
-        if not 'height' in vars:
+        if 'height' not in vars:
             vars['height'] = Var(VarType.INT, 1)
         super(DeathZone, self).__init__(
             vars, rotation, layer, unk2, unk3, unk4)
 
     def width(self, val=None):
         result = self.vars['width'].value / 48.0
-        if not val is None:
+        if val is not None:
             self.vars['width'].value = round(val * 48)
         return result
 
     def height(self, val=None):
         result = self.vars['height'].value / 48.0
-        if not val is None:
+        if val is not None:
             self.vars['height'].value = round(val * 48)
         return result
 
     def transform(self, mat):
-        w = self.width()
-        h = self.height()
-        self.width(abs(w * mat[0][0] + h * mat[0][1]))
-        self.height(abs(w * mat[1][0] + h * mat[1][1]))
+        width = self.width()
+        height = self.height()
+        self.width(abs(width * mat[0][0] + height * mat[0][1]))
+        self.height(abs(width * mat[1][0] + height * mat[1][1]))
         super(DeathZone, self).transform(mat)
 
 known_types.append(DeathZone)
@@ -147,16 +147,16 @@ class AIController(Entity):
 
     def __init__(self, vars, rotation=0,
                  layer=0, unk2=0, unk3=0, unk4=0):
-        if not 'puppet_id' in vars:
+        if 'puppet_id' not in vars:
             vars['puppet_id'] = Var(VarType.INT, 0)
-        if not 'nodes' in vars:
+        if 'nodes' not in vars:
             vars['nodes'] = Var(VarType.ARRAY, (VarType.VEC2, []))
         super(AIController, self).__init__(
             vars, rotation, layer, unk2, unk3, unk4)
 
     def puppet(self, val=None):
         result = self.vars['puppet_id'].value
-        if not val is None:
+        if val is not None:
             self.vars['puppet_id'].value = val
         return result
 
@@ -165,7 +165,7 @@ class AIController(Entity):
 
     def node_position(self, ind, val=None):
         result = self.vars['nodes'].value[1][ind].value
-        if not val is None:
+        if val is not None:
             self.vars['nodes'].value[1][ind] = Var(VarType.VEC2,
                                                    (val[0] * 48, val[1] * 48))
         return (result[0] / 48, result[1] / 48)
@@ -189,9 +189,11 @@ class AIController(Entity):
     def transform(self, mat):
         for i in range(self.node_count()):
             pos = self.node_position(i)
-            self.node_position(i,
-                               (mat[0][2] + pos[0] * mat[0][0] + pos[1] * mat[0][1],
-                                mat[1][2] + pos[0] * mat[1][0] + pos[1] * mat[1][1]))
+            self.node_position(
+                i,
+                (mat[0][2] + pos[0] * mat[0][0] + pos[1] * mat[0][1],
+                 mat[1][2] + pos[0] * mat[1][0] + pos[1] * mat[1][1])
+            )
         super(AIController, self).transform(mat)
 
 known_types.append(AIController)
@@ -202,7 +204,7 @@ class CameraNode(Entity):
 
     def __init__(self, vars, rotation=0,
                  layer=0, unk2=0, unk3=0, unk4=0):
-        if not 'c_node_ids' in vars:
+        if 'c_node_ids' not in vars:
             vars['c_node_ids'] = Var(VarType.ARRAY, (VarType.INT, []))
         super(CameraNode, self).__init__(
             vars, rotation, layer, unk2, unk3, unk4)
@@ -212,7 +214,7 @@ class CameraNode(Entity):
 
     def connection(self, ind, val=None):
         result = self.vars['c_node_ids'].value[1][ind].value
-        if not val is None:
+        if val is not None:
             self.vars['c_node_ids'].value[1][ind] = Var(VarType.INT, val)
         return result
 
@@ -237,7 +239,7 @@ class LevelEnd(Entity):
 
     def __init__(self, vars, rotation=0,
                  layer=0, unk2=0, unk3=0, unk4=0):
-        if not 'ent_list' in vars:
+        if 'ent_list' not in vars:
             vars['ent_list'] = Var(VarType.ARRAY, (VarType.INT, []))
         super(LevelEnd, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
 
@@ -246,7 +248,7 @@ class LevelEnd(Entity):
 
     def entity(self, ind, val=None):
         result = self.vars['ent_list'].value[1][ind].value
-        if not val is None:
+        if val is not None:
             self.vars['ent_list'].value[1][ind] = Var(VarType.INT, val)
         return result
 
@@ -268,13 +270,15 @@ known_types.append(LevelEnd)
 
 class Enemy(Entity):
 
-    def __init__(self, vars={}, rotation=0, layer=18, unk2=1,
+    def __init__(self, vars=None, rotation=0, layer=18, unk2=1,
                  unk3=1, unk4=1):
         super(Enemy, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
 
-    def filth(self): return 1
+    def filth(self):
+        return 1
 
-    def combo(self): return self.filth()
+    def combo(self):
+        return self.filth()
 
 
 class EnemyLightPrism(Enemy):
@@ -284,73 +288,85 @@ class EnemyLightPrism(Enemy):
 class EnemyHeavyPrism(Enemy):
     TYPE_IDENTIFIER = "enemy_tutorial_hexagon"
 
-    def combo(self): return 3
+    def combo(self):
+        return 3
 
 
 class EnemySlimeBeast(Enemy):
     TYPE_IDENTIFIER = "enemy_slime_beast"
 
-    def filth(self): return 9
+    def filth(self):
+        return 9
 
 
 class EnemySlimeBarrel(Enemy):
     TYPE_IDENTIFIER = "enemy_slime_barrel"
 
-    def filth(self): return 3
+    def filth(self):
+        return 3
 
 
 class EnemySpringBall(Enemy):
     TYPE_IDENTIFIER = "enemy_spring_ball"
 
-    def filth(self): return 5
+    def filth(self):
+        return 5
 
 
 class EnemySlimeBall(Enemy):
     TYPE_IDENTIFIER = "enemy_slime_ball"
 
-    def filth(self): return 3
+    def filth(self):
+        return 3
 
 
 class EnemyTrashTire(Enemy):
     TYPE_IDENTIFIER = "enemy_trash_tire"
 
-    def filth(self): return 3
+    def filth(self):
+        return 3
 
 
 class EnemyTrashBeast(Enemy):
     TYPE_IDENTIFIER = "enemy_trash_beast"
 
-    def filth(self): return 9
+    def filth(self):
+        return 9
 
 
 class EnemyTrashCan(Enemy):
     TYPE_IDENTIFIER = "enemy_trash_can"
 
-    def filth(self): return 9
+    def filth(self):
+        return 9
 
 
 class EnemyTrashBall(Enemy):
     TYPE_IDENTIFIER = "enemy_trash_ball"
 
-    def filth(self): return 3
+    def filth(self):
+        return 3
 
 
 class EnemyBear(Enemy):
     TYPE_IDENTIFIER = "enemy_bear"
 
-    def filth(self): return 9
+    def filth(self):
+        return 9
 
 
 class EnemyTotemLarge(Enemy):
     TYPE_IDENTIFIER = "enemy_stoneboss"
 
-    def filth(self): return 12
+    def filth(self):
+        return 12
 
 
 class EnemyTotemSmall(Enemy):
     TYPE_IDENTIFIER = "enemy_stonebro"
 
-    def filth(self): return 3
+    def filth(self):
+        return 3
 
 
 class EnemyPorcupine(Enemy):
@@ -360,19 +376,22 @@ class EnemyPorcupine(Enemy):
 class EnemyWolf(Enemy):
     TYPE_IDENTIFIER = "enemy_wolf"
 
-    def filth(self): return 5
+    def filth(self):
+        return 5
 
 
 class EnemyTurkey(Enemy):
     TYPE_IDENTIFIER = "enemy_critter"
 
-    def filth(self): return 3
+    def filth(self):
+        return 3
 
 
 class EnemyFlag(Enemy):
     TYPE_IDENTIFIER = "enemy_flag"
 
-    def filth(self): return 5
+    def filth(self):
+        return 5
 
 
 class EnemyScroll(Enemy):
@@ -386,13 +405,15 @@ class EnemyTreasure(Enemy):
 class EnemyChestTreasure(Enemy):
     TYPE_IDENTIFIER = "enemy_chest_treasure"
 
-    def filth(self): return 9
+    def filth(self):
+        return 9
 
 
 class EnemyChestScrolls(Enemy):
     TYPE_IDENTIFIER = "enemy_chest_scrolls"
 
-    def filth(self): return 9
+    def filth(self):
+        return 9
 
 
 class EnemyButler(Enemy):
@@ -406,31 +427,37 @@ class EnemyMaid(Enemy):
 class EnemyKnight(Enemy):
     TYPE_IDENTIFIER = "enemy_knight"
 
-    def filth(self): return 9
+    def filth(self):
+        return 9
 
 
 class EnemyGargoyleBig(Enemy):
     TYPE_IDENTIFIER = "enemy_gargoyle_big"
 
-    def filth(self): return 5
+    def filth(self):
+        return 5
 
 
 class EnemyGargoyleSmall(Enemy):
     TYPE_IDENTIFIER = "enemy_gargoyle_small"
 
-    def filth(self): return 3
+    def filth(self):
+        return 3
 
 
 class EnemyBook(Enemy):
     TYPE_IDENTIFIER = "enemy_book"
 
-    def filth(self): return 3
+    def filth(self):
+        return 3
 
 
 class EnemyHawk(Enemy):
     TYPE_IDENTIFIER = "enemy_hawk"
 
-    def filth(self): return 3
+    def filth(self):
+        return 3
+
 
 known_types.append(EnemyLightPrism)
 known_types.append(EnemyHeavyPrism)
@@ -496,6 +523,7 @@ class Trashking(Entity):
 
 class Slimeboss(Entity):
     TYPE_IDENTIFIER = "slime_boss"
+
 
 known_types.append(Apple)
 known_types.append(Dustman)

--- a/dustmaker/Entity.py
+++ b/dustmaker/Entity.py
@@ -4,362 +4,433 @@ import math
 
 known_types = []
 
+
 class Entity:
-  @staticmethod
-  def _from_raw(type, vars, rotation, layer, unk2, unk3, unk4):
-    for class_type in known_types:
-      if type == class_type.TYPE_IDENTIFIER:
-        return class_type(vars, rotation, layer, unk2, unk3, unk4)
-    entity = Entity(vars, rotation, layer, unk2, unk3, unk4)
-    entity.type = type
-    return entity
 
-  def __init__(self, vars = {}, rotation = 0,
-               layer = 18, unk2 = 1, unk3 = 1, unk4 = 1):
-    if hasattr(self, "TYPE_IDENTIFIER"):
-      self.type = self.TYPE_IDENTIFIER
-    self.vars = vars
-    self.rotation = rotation
-    self.layer = layer
-    self.unk2 = unk2
-    self.unk3 = unk3
-    self.unk4 = unk4
+    @staticmethod
+    def _from_raw(type, vars, rotation, layer, unk2, unk3, unk4):
+        for class_type in known_types:
+            if type == class_type.TYPE_IDENTIFIER:
+                return class_type(vars, rotation, layer, unk2, unk3, unk4)
+        entity = Entity(vars, rotation, layer, unk2, unk3, unk4)
+        entity.type = type
+        return entity
 
-  def __repr__(self):
-    return "Entity: (%s, %d, %d, %d, %d, %d, %s)" % (
-              self.type, self.rotation, self.layer, self.unk2, self.unk3,
-              self.unk4, repr(self.vars))
+    def __init__(self, vars={}, rotation=0,
+                 layer=18, unk2=1, unk3=1, unk4=1):
+        if hasattr(self, "TYPE_IDENTIFIER"):
+            self.type = self.TYPE_IDENTIFIER
+        self.vars = vars
+        self.rotation = rotation
+        self.layer = layer
+        self.unk2 = unk2
+        self.unk3 = unk3
+        self.unk4 = unk4
 
-  def remap_ids(self, id_map):
-    pass
+    def __repr__(self):
+        return "Entity: (%s, %d, %d, %d, %d, %d, %s)" % (
+            self.type, self.rotation, self.layer, self.unk2, self.unk3,
+            self.unk4, repr(self.vars))
 
-  def transform(self, mat):
-    angle = math.atan2(mat[1][1], mat[1][0]) - math.pi / 2
-    self.rotation = self.rotation - int(0x10000 * angle / math.pi / 2) & 0xFFFF
+    def remap_ids(self, id_map):
+        pass
 
-    if mat[0][0] * mat[1][1] - mat[0][1] * mat[1][0] < 0:
-      self.unk3 = 1 - self.unk3
-      self.rotation = -self.rotation & 0xFFFF
+    def transform(self, mat):
+        angle = math.atan2(mat[1][1], mat[1][0]) - math.pi / 2
+        self.rotation = self.rotation - \
+            int(0x10000 * angle / math.pi / 2) & 0xFFFF
+
+        if mat[0][0] * mat[1][1] - mat[0][1] * mat[1][0] < 0:
+            self.unk3 = 1 - self.unk3
+            self.rotation = -self.rotation & 0xFFFF
+
 
 class TriggerArea(Entity):
-  def __init__(self, vars, rotation = 0,
-               layer = 0, unk2 = 0, unk3 = 0, unk4 = 0):
-    if not 'trigger_area' in vars:
-      vars['trigger_area'] = Var(VarType.ARRAY, (VarType.VEC2, []))
-    super(TriggerArea, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
 
-  def area_count(self):
-    return len(self.vars['trigger_area'].value[1])
+    def __init__(self, vars, rotation=0,
+                 layer=0, unk2=0, unk3=0, unk4=0):
+        if not 'trigger_area' in vars:
+            vars['trigger_area'] = Var(VarType.ARRAY, (VarType.VEC2, []))
+        super(TriggerArea, self).__init__(
+            vars, rotation, layer, unk2, unk3, unk4)
 
-  def area_position(self, ind, val = None):
-    result = self.vars['trigger_area'].value[1][ind].value
-    if not val is None:
-      self.vars['trigger_area'].value[1][ind] = Var(VarType.VEC2, val)
-    return result
+    def area_count(self):
+        return len(self.vars['trigger_area'].value[1])
 
-  def area_append(self, val):
-    self.vars['trigger_area'].value[1].append(Var(VarType.VEC2, val))
-    
-  def area_pop(self, ind = None):
-    return self.vars['trigger_area'].value[1].pop(ind).value
+    def area_position(self, ind, val=None):
+        result = self.vars['trigger_area'].value[1][ind].value
+        if not val is None:
+            self.vars['trigger_area'].value[1][ind] = Var(VarType.VEC2, val)
+        return result
 
-  def area_clear(self):
-    self.vars['trigger_area'].value[1] = []
+    def area_append(self, val):
+        self.vars['trigger_area'].value[1].append(Var(VarType.VEC2, val))
 
-  def transform(self, mat):
-    for i in range(self.area_count()):
-      pos = self.area_position(i)
-      self.area_position(i,
-          (pos[0] * mat[0][0] + pos[1] * mat[0][1],
-           pos[0] * mat[1][0] + pos[1] * mat[1][1]))
-    super(TriggerArea, self).transform(mat)
+    def area_pop(self, ind=None):
+        return self.vars['trigger_area'].value[1].pop(ind).value
+
+    def area_clear(self):
+        self.vars['trigger_area'].value[1] = []
+
+    def transform(self, mat):
+        for i in range(self.area_count()):
+            pos = self.area_position(i)
+            self.area_position(i,
+                               (pos[0] * mat[0][0] + pos[1] * mat[0][1],
+                                pos[0] * mat[1][0] + pos[1] * mat[1][1]))
+        super(TriggerArea, self).transform(mat)
+
 
 class CheckPoint(TriggerArea):
-  TYPE_IDENTIFIER = "check_point"
+    TYPE_IDENTIFIER = "check_point"
 
 known_types.append(CheckPoint)
 
+
 class EndZone(TriggerArea):
-  TYPE_IDENTIFIER = "level_end_prox"
+    TYPE_IDENTIFIER = "level_end_prox"
 
 known_types.append(EndZone)
 
+
 class Trigger(Entity):
-  def __init__(self, vars, rotation = 0,
-               layer = 0, unk2 = 0, unk3 = 0, unk4 = 0):
-    if not 'width' in vars:
-      vars['width'] = Var(VarType.UINT, 500)
-    super(Trigger, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
+
+    def __init__(self, vars, rotation=0,
+                 layer=0, unk2=0, unk3=0, unk4=0):
+        if not 'width' in vars:
+            vars['width'] = Var(VarType.UINT, 500)
+        super(Trigger, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
+
 
 class FogTrigger(Trigger):
-  TYPE_IDENTIFIER = "fog_trigger"
+    TYPE_IDENTIFIER = "fog_trigger"
 
 known_types.append(FogTrigger)
 
+
 class DeathZone(Entity):
-  TYPE_IDENTIFIER = "kill_box"
+    TYPE_IDENTIFIER = "kill_box"
 
-  def __init__(self, vars, rotation = 0,
-               layer = 0, unk2 = 0, unk3 = 0, unk4 = 0):
-    if not 'width' in vars:
-      vars['width'] = Var(VarType.INT, 1)
-    if not 'height' in vars:
-      vars['height'] = Var(VarType.INT, 1)
-    super(DeathZone, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
+    def __init__(self, vars, rotation=0,
+                 layer=0, unk2=0, unk3=0, unk4=0):
+        if not 'width' in vars:
+            vars['width'] = Var(VarType.INT, 1)
+        if not 'height' in vars:
+            vars['height'] = Var(VarType.INT, 1)
+        super(DeathZone, self).__init__(
+            vars, rotation, layer, unk2, unk3, unk4)
 
-  def width(self, val = None):
-    result = self.vars['width'].value / 48.0
-    if not val is None:
-      self.vars['width'].value = round(val * 48)
-    return result
+    def width(self, val=None):
+        result = self.vars['width'].value / 48.0
+        if not val is None:
+            self.vars['width'].value = round(val * 48)
+        return result
 
-  def height(self, val = None):
-    result = self.vars['height'].value / 48.0
-    if not val is None:
-      self.vars['height'].value = round(val * 48)
-    return result
+    def height(self, val=None):
+        result = self.vars['height'].value / 48.0
+        if not val is None:
+            self.vars['height'].value = round(val * 48)
+        return result
 
-  def transform(self, mat):
-    w = self.width()
-    h = self.height()
-    self.width(abs(w * mat[0][0] + h * mat[0][1]))
-    self.height(abs(w * mat[1][0] + h * mat[1][1]))
-    super(DeathZone, self).transform(mat)
+    def transform(self, mat):
+        w = self.width()
+        h = self.height()
+        self.width(abs(w * mat[0][0] + h * mat[0][1]))
+        self.height(abs(w * mat[1][0] + h * mat[1][1]))
+        super(DeathZone, self).transform(mat)
 
 known_types.append(DeathZone)
 
+
 class AIController(Entity):
-  TYPE_IDENTIFIER = "AI_controller"
+    TYPE_IDENTIFIER = "AI_controller"
 
-  def __init__(self, vars, rotation = 0,
-               layer = 0, unk2 = 0, unk3 = 0, unk4 = 0):
-    if not 'puppet_id' in vars:
-      vars['puppet_id'] = Var(VarType.INT, 0)
-    if not 'nodes' in vars:
-      vars['nodes'] = Var(VarType.ARRAY, (VarType.VEC2, []))
-    super(AIController, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
+    def __init__(self, vars, rotation=0,
+                 layer=0, unk2=0, unk3=0, unk4=0):
+        if not 'puppet_id' in vars:
+            vars['puppet_id'] = Var(VarType.INT, 0)
+        if not 'nodes' in vars:
+            vars['nodes'] = Var(VarType.ARRAY, (VarType.VEC2, []))
+        super(AIController, self).__init__(
+            vars, rotation, layer, unk2, unk3, unk4)
 
-  def puppet(self, val = None):
-    result = self.vars['puppet_id'].value
-    if not val is None:
-      self.vars['puppet_id'].value = val
-    return result
+    def puppet(self, val=None):
+        result = self.vars['puppet_id'].value
+        if not val is None:
+            self.vars['puppet_id'].value = val
+        return result
 
-  def node_count(self):
-    return len(self.vars['nodes'].value[1])
+    def node_count(self):
+        return len(self.vars['nodes'].value[1])
 
-  def node_position(self, ind, val = None):
-    result = self.vars['nodes'].value[1][ind].value
-    if not val is None:
-      self.vars['nodes'].value[1][ind] = Var(VarType.VEC2,
-                                             (val[0] * 48, val[1] * 48))
-    return (result[0] / 48, result[1] / 48)
+    def node_position(self, ind, val=None):
+        result = self.vars['nodes'].value[1][ind].value
+        if not val is None:
+            self.vars['nodes'].value[1][ind] = Var(VarType.VEC2,
+                                                   (val[0] * 48, val[1] * 48))
+        return (result[0] / 48, result[1] / 48)
 
-  def node_append(self, val):
-    self.vars['nodes'].value[1].append(Var(VarType.VEC2,
-                                           (val[0] * 48, val[1] * 48)))
+    def node_append(self, val):
+        self.vars['nodes'].value[1].append(Var(VarType.VEC2,
+                                               (val[0] * 48, val[1] * 48)))
 
-  def node_pop(self, ind = None):
-    return self.vars['nodes'].value[1].pop(ind).value
+    def node_pop(self, ind=None):
+        return self.vars['nodes'].value[1].pop(ind).value
 
-  def node_clear(self):
-    self.vars['nodes'].value[1] = []
+    def node_clear(self):
+        self.vars['nodes'].value[1] = []
 
-  def remap_ids(self, id_map):
-    if self.puppet() in id_map:
-      self.puppet(id_map[self.puppet()])
-    else:
-      self.puppet(-1)
+    def remap_ids(self, id_map):
+        if self.puppet() in id_map:
+            self.puppet(id_map[self.puppet()])
+        else:
+            self.puppet(-1)
 
-  def transform(self, mat):
-    for i in range(self.node_count()):
-      pos = self.node_position(i)
-      self.node_position(i,
-          (mat[0][2] + pos[0] * mat[0][0] + pos[1] * mat[0][1],
-           mat[1][2] + pos[0] * mat[1][0] + pos[1] * mat[1][1]))
-    super(AIController, self).transform(mat)
+    def transform(self, mat):
+        for i in range(self.node_count()):
+            pos = self.node_position(i)
+            self.node_position(i,
+                               (mat[0][2] + pos[0] * mat[0][0] + pos[1] * mat[0][1],
+                                mat[1][2] + pos[0] * mat[1][0] + pos[1] * mat[1][1]))
+        super(AIController, self).transform(mat)
 
 known_types.append(AIController)
 
+
 class CameraNode(Entity):
-  TYPE_IDENTIFIER = "camera_node"
+    TYPE_IDENTIFIER = "camera_node"
 
-  def __init__(self, vars, rotation = 0,
-               layer = 0, unk2 = 0, unk3 = 0, unk4 = 0):
-    if not 'c_node_ids' in vars:
-      vars['c_node_ids'] = Var(VarType.ARRAY, (VarType.INT, []))
-    super(CameraNode, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
+    def __init__(self, vars, rotation=0,
+                 layer=0, unk2=0, unk3=0, unk4=0):
+        if not 'c_node_ids' in vars:
+            vars['c_node_ids'] = Var(VarType.ARRAY, (VarType.INT, []))
+        super(CameraNode, self).__init__(
+            vars, rotation, layer, unk2, unk3, unk4)
 
-  def connection_count(self):
-    return len(self.vars['c_node_ids'].value[1])
+    def connection_count(self):
+        return len(self.vars['c_node_ids'].value[1])
 
-  def connection(self, ind, val = None):
-    result = self.vars['c_node_ids'].value[1][ind].value
-    if not val is None:
-      self.vars['c_node_ids'].value[1][ind] = Var(VarType.INT, val)
-    return result
+    def connection(self, ind, val=None):
+        result = self.vars['c_node_ids'].value[1][ind].value
+        if not val is None:
+            self.vars['c_node_ids'].value[1][ind] = Var(VarType.INT, val)
+        return result
 
-  def connection_append(self, val):
-    self.vars['c_node_ids'].value[1].append(Var(VarType.INT, val))
+    def connection_append(self, val):
+        self.vars['c_node_ids'].value[1].append(Var(VarType.INT, val))
 
-  def connection_pop(self, ind = None):
-    return self.vars['c_node_ids'].value[1].pop(ind).value
+    def connection_pop(self, ind=None):
+        return self.vars['c_node_ids'].value[1].pop(ind).value
 
-  def connection_clear(self):
-    self.vars['c_node_ids'].value = (VarType.INT, [])
+    def connection_clear(self):
+        self.vars['c_node_ids'].value = (VarType.INT, [])
 
-  def remap_ids(self, id_map):
-    for i in range(self.connection_count()):
-      self.connection(i, id_map[self.connection(i)])
+    def remap_ids(self, id_map):
+        for i in range(self.connection_count()):
+            self.connection(i, id_map[self.connection(i)])
 
 known_types.append(CameraNode)
 
+
 class LevelEnd(Entity):
-  TYPE_IDENTIFIER = "level_end"
+    TYPE_IDENTIFIER = "level_end"
 
-  def __init__(self, vars, rotation = 0,
-               layer = 0, unk2 = 0, unk3 = 0, unk4 = 0):
-    if not 'ent_list' in vars:
-      vars['ent_list'] = Var(VarType.ARRAY, (VarType.INT, []))
-    super(LevelEnd, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
+    def __init__(self, vars, rotation=0,
+                 layer=0, unk2=0, unk3=0, unk4=0):
+        if not 'ent_list' in vars:
+            vars['ent_list'] = Var(VarType.ARRAY, (VarType.INT, []))
+        super(LevelEnd, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
 
-  def entity_count(self):
-    return len(self.vars['ent_list'].value[1])
+    def entity_count(self):
+        return len(self.vars['ent_list'].value[1])
 
-  def entity(self, ind, val = None):
-    result = self.vars['ent_list'].value[1][ind].value
-    if not val is None:
-      self.vars['ent_list'].value[1][ind] = Var(VarType.INT, val)
-    return result
+    def entity(self, ind, val=None):
+        result = self.vars['ent_list'].value[1][ind].value
+        if not val is None:
+            self.vars['ent_list'].value[1][ind] = Var(VarType.INT, val)
+        return result
 
-  def entity_append(self, val):
-    self.vars['ent_list'].value[1].append(Var(VarType.INT, val))
+    def entity_append(self, val):
+        self.vars['ent_list'].value[1].append(Var(VarType.INT, val))
 
-  def entity_pop(self, ind = None):
-    return self.vars['ent_list'].value[1].pop(ind).value
+    def entity_pop(self, ind=None):
+        return self.vars['ent_list'].value[1].pop(ind).value
 
-  def entity_clear(self):
-    self.vars['ent_list'].value[1] = []
+    def entity_clear(self):
+        self.vars['ent_list'].value[1] = []
 
-  def remap_ids(self, id_map):
-    for i in range(self.entity_count()):
-      self.entity(i, id_map[self.entity(i)])
+    def remap_ids(self, id_map):
+        for i in range(self.entity_count()):
+            self.entity(i, id_map[self.entity(i)])
 
 known_types.append(LevelEnd)
 
-class Enemy(Entity):
-  def __init__(self, vars = {}, rotation = 0, layer = 18, unk2 = 1,
-               unk3 = 1, unk4 = 1):
-    super(Enemy, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
 
-  def filth(self): return 1
-  def combo(self): return self.filth()
+class Enemy(Entity):
+
+    def __init__(self, vars={}, rotation=0, layer=18, unk2=1,
+                 unk3=1, unk4=1):
+        super(Enemy, self).__init__(vars, rotation, layer, unk2, unk3, unk4)
+
+    def filth(self): return 1
+
+    def combo(self): return self.filth()
+
 
 class EnemyLightPrism(Enemy):
-  TYPE_IDENTIFIER = "enemy_tutorial_square"
+    TYPE_IDENTIFIER = "enemy_tutorial_square"
+
 
 class EnemyHeavyPrism(Enemy):
-  TYPE_IDENTIFIER = "enemy_tutorial_hexagon"
-  def combo(self): return 3
+    TYPE_IDENTIFIER = "enemy_tutorial_hexagon"
+
+    def combo(self): return 3
+
 
 class EnemySlimeBeast(Enemy):
-  TYPE_IDENTIFIER = "enemy_slime_beast"
-  def filth(self): return 9
+    TYPE_IDENTIFIER = "enemy_slime_beast"
+
+    def filth(self): return 9
+
 
 class EnemySlimeBarrel(Enemy):
-  TYPE_IDENTIFIER = "enemy_slime_barrel"
-  def filth(self): return 3
+    TYPE_IDENTIFIER = "enemy_slime_barrel"
+
+    def filth(self): return 3
+
 
 class EnemySpringBall(Enemy):
-  TYPE_IDENTIFIER = "enemy_spring_ball"
-  def filth(self): return 5
+    TYPE_IDENTIFIER = "enemy_spring_ball"
+
+    def filth(self): return 5
+
 
 class EnemySlimeBall(Enemy):
-  TYPE_IDENTIFIER = "enemy_slime_ball"
-  def filth(self): return 3
+    TYPE_IDENTIFIER = "enemy_slime_ball"
+
+    def filth(self): return 3
+
 
 class EnemyTrashTire(Enemy):
-  TYPE_IDENTIFIER = "enemy_trash_tire"
-  def filth(self): return 3
+    TYPE_IDENTIFIER = "enemy_trash_tire"
+
+    def filth(self): return 3
+
 
 class EnemyTrashBeast(Enemy):
-  TYPE_IDENTIFIER = "enemy_trash_beast"
-  def filth(self): return 9
+    TYPE_IDENTIFIER = "enemy_trash_beast"
+
+    def filth(self): return 9
+
 
 class EnemyTrashCan(Enemy):
-  TYPE_IDENTIFIER = "enemy_trash_can"
-  def filth(self): return 9
+    TYPE_IDENTIFIER = "enemy_trash_can"
+
+    def filth(self): return 9
+
 
 class EnemyTrashBall(Enemy):
-  TYPE_IDENTIFIER = "enemy_trash_ball"
-  def filth(self): return 3
+    TYPE_IDENTIFIER = "enemy_trash_ball"
+
+    def filth(self): return 3
+
 
 class EnemyBear(Enemy):
-  TYPE_IDENTIFIER = "enemy_bear"
-  def filth(self): return 9
+    TYPE_IDENTIFIER = "enemy_bear"
+
+    def filth(self): return 9
+
 
 class EnemyTotemLarge(Enemy):
-  TYPE_IDENTIFIER = "enemy_stoneboss"
-  def filth(self): return 12
+    TYPE_IDENTIFIER = "enemy_stoneboss"
+
+    def filth(self): return 12
+
 
 class EnemyTotemSmall(Enemy):
-  TYPE_IDENTIFIER = "enemy_stonebro"
-  def filth(self): return 3
+    TYPE_IDENTIFIER = "enemy_stonebro"
+
+    def filth(self): return 3
+
 
 class EnemyPorcupine(Enemy):
-  TYPE_IDENTIFIER = "enemy_porcupine"
+    TYPE_IDENTIFIER = "enemy_porcupine"
+
 
 class EnemyWolf(Enemy):
-  TYPE_IDENTIFIER = "enemy_wolf"
-  def filth(self): return 5
+    TYPE_IDENTIFIER = "enemy_wolf"
+
+    def filth(self): return 5
+
 
 class EnemyTurkey(Enemy):
-  TYPE_IDENTIFIER = "enemy_critter"
-  def filth(self): return 3
+    TYPE_IDENTIFIER = "enemy_critter"
+
+    def filth(self): return 3
+
 
 class EnemyFlag(Enemy):
-  TYPE_IDENTIFIER = "enemy_flag"
-  def filth(self): return 5
+    TYPE_IDENTIFIER = "enemy_flag"
+
+    def filth(self): return 5
+
 
 class EnemyScroll(Enemy):
-  TYPE_IDENTIFIER = "enemy_scrolls"
+    TYPE_IDENTIFIER = "enemy_scrolls"
+
 
 class EnemyTreasure(Enemy):
-  TYPE_IDENTIFIER = "enemy_treasure"
+    TYPE_IDENTIFIER = "enemy_treasure"
+
 
 class EnemyChestTreasure(Enemy):
-  TYPE_IDENTIFIER = "enemy_chest_treasure"
-  def filth(self): return 9
+    TYPE_IDENTIFIER = "enemy_chest_treasure"
+
+    def filth(self): return 9
+
 
 class EnemyChestScrolls(Enemy):
-  TYPE_IDENTIFIER = "enemy_chest_scrolls"
-  def filth(self): return 9
+    TYPE_IDENTIFIER = "enemy_chest_scrolls"
+
+    def filth(self): return 9
+
 
 class EnemyButler(Enemy):
-  TYPE_IDENTIFIER = "enemy_butler"
+    TYPE_IDENTIFIER = "enemy_butler"
+
 
 class EnemyMaid(Enemy):
-  TYPE_IDENTIFIER = "enemy_maid"
+    TYPE_IDENTIFIER = "enemy_maid"
+
 
 class EnemyKnight(Enemy):
-  TYPE_IDENTIFIER = "enemy_knight"
-  def filth(self): return 9
+    TYPE_IDENTIFIER = "enemy_knight"
+
+    def filth(self): return 9
+
 
 class EnemyGargoyleBig(Enemy):
-  TYPE_IDENTIFIER = "enemy_gargoyle_big"
-  def filth(self): return 5
+    TYPE_IDENTIFIER = "enemy_gargoyle_big"
+
+    def filth(self): return 5
+
 
 class EnemyGargoyleSmall(Enemy):
-  TYPE_IDENTIFIER = "enemy_gargoyle_small"
-  def filth(self): return 3
+    TYPE_IDENTIFIER = "enemy_gargoyle_small"
+
+    def filth(self): return 3
+
 
 class EnemyBook(Enemy):
-  TYPE_IDENTIFIER = "enemy_book"
-  def filth(self): return 3
+    TYPE_IDENTIFIER = "enemy_book"
+
+    def filth(self): return 3
+
 
 class EnemyHawk(Enemy):
-  TYPE_IDENTIFIER = "enemy_hawk"
-  def filth(self): return 3
+    TYPE_IDENTIFIER = "enemy_hawk"
+
+    def filth(self): return 3
 
 known_types.append(EnemyLightPrism)
 known_types.append(EnemyHeavyPrism)
@@ -390,32 +461,41 @@ known_types.append(EnemyGargoyleSmall)
 known_types.append(EnemyBook)
 known_types.append(EnemyHawk)
 
+
 class Apple(Entity):
-  TYPE_IDENTIFIER = "hittable_apple"
+    TYPE_IDENTIFIER = "hittable_apple"
+
 
 class Dustman(Entity):
-  TYPE_IDENTIFIER = "dust_man"
+    TYPE_IDENTIFIER = "dust_man"
+
 
 class Dustgirl(Entity):
-  TYPE_IDENTIFIER = "dust_girl"
+    TYPE_IDENTIFIER = "dust_girl"
+
 
 class Dustkid(Entity):
-  TYPE_IDENTIFIER = "dust_kid"
+    TYPE_IDENTIFIER = "dust_kid"
+
 
 class Dustworth(Entity):
-  TYPE_IDENTIFIER = "dust_worth"
+    TYPE_IDENTIFIER = "dust_worth"
+
 
 class Dustwraith(Entity):
-  TYPE_IDENTIFIER = "dust_wraith"
+    TYPE_IDENTIFIER = "dust_wraith"
+
 
 class Leafsprite(Entity):
-  TYPE_IDENTIFIER = "leaf_sprite"
+    TYPE_IDENTIFIER = "leaf_sprite"
+
 
 class Trashking(Entity):
-  TYPE_IDENTIFIER = "trash_king"
+    TYPE_IDENTIFIER = "trash_king"
+
 
 class Slimeboss(Entity):
-  TYPE_IDENTIFIER = "slime_boss"
+    TYPE_IDENTIFIER = "slime_boss"
 
 known_types.append(Apple)
 known_types.append(Dustman)

--- a/dustmaker/Map.py
+++ b/dustmaker/Map.py
@@ -3,296 +3,296 @@ from .Var import Var, VarType
 
 import copy
 
+
 class Map:
-  """ Represents a Dustforce level.
+    """ Represents a Dustforce level.
 
-      A map contains the following attributes:
+        A map contains the following attributes:
 
-      map.tiles - A dict mapping (layer, x, y) to Tile objects.
-      map.props - A dict mapping prop ids to Prop objects.
-      map.parent - For backdrops this is the containing map.  Otherwise this is
-                   set to None.
+        map.tiles - A dict mapping (layer, x, y) to Tile objects.
+        map.props - A dict mapping prop ids to Prop objects.
+        map.parent - For backdrops this is the containing map.  Otherwise this is
+                     set to None.
 
-      If the map is not a backdrop (i.e. map.parent == None) then the following
-      attributes will also be available:
+        If the map is not a backdrop (i.e. map.parent == None) then the following
+        attributes will also be available:
 
-      map.entities - A dict mapping entity ids to Entity objects.
-      map.backdrop - The backdrop Map object.  Backdrop maps can only contain
-                     tiles and props and each tile is the size of 16 tiles in
-                     the top level coordinate system.
-      map.vars - A raw mapping of string keys to Var objects.  Some of these
-                 variables have nicer accessors like map.name(...).
-      map.sshot - The level thumbnail image.  This appears to be a PNG image
-                   with some custom or missing header.
-  """
-
-  def __init__(self, parent = None):
-    """ Constructs a blank level object.
-
-        parent - If this Map represents a backdrop this is the containing map.
-                 Typical usage should not need to use this parameter.
+        map.entities - A dict mapping entity ids to Entity objects.
+        map.backdrop - The backdrop Map object.  Backdrop maps can only contain
+                       tiles and props and each tile is the size of 16 tiles in
+                       the top level coordinate system.
+        map.vars - A raw mapping of string keys to Var objects.  Some of these
+                   variables have nicer accessors like map.name(...).
+        map.sshot - The level thumbnail image.  This appears to be a PNG image
+                     with some custom or missing header.
     """
-    self._min_id = 100
-    self.tiles = {}
-    self.props = {}
-    self.vars = {}
 
-    self.parent = parent
-    if not parent:
-      self.sshot = b""
-      self.entities = {}
-      self.backdrop = Map(self)
+    def __init__(self, parent=None):
+        """ Constructs a blank level object.
 
-  def _next_id(self):
-    if self.parent:
-      return self.parent._next_id()
-    result = self._min_id
-    self._min_id += 1
-    return result
+            parent - If this Map represents a backdrop this is the containing map.
+                     Typical usage should not need to use this parameter.
+        """
+        self._min_id = 100
+        self.tiles = {}
+        self.props = {}
+        self.vars = {}
 
-  def _note_id(self, id):
-    if self.parent:
-      return self.parent._note_id(id)
-    self._min_id = max(self._min_id, id + 1)
+        self.parent = parent
+        if not parent:
+            self.sshot = b""
+            self.entities = {}
+            self.backdrop = Map(self)
 
-  def _var_access(self, key, type, val = None, default = None):
-    result = default
-    if key in self.vars:
-      result = self.vars[key].value
-    if not val is None:
-      self.vars[key] = Var(type, val)
-    return result
+    def _next_id(self):
+        if self.parent:
+            return self.parent._next_id()
+        result = self._min_id
+        self._min_id += 1
+        return result
 
-  def name(self, val = None):
-    """ Returns the level name.
+    def _note_id(self, id):
+        if self.parent:
+            return self.parent._note_id(id)
+        self._min_id = max(self._min_id, id + 1)
 
-        val - If not None sets the new name of the Map.
-    """
-    return self._var_access("level_name", VarType.STRING, val, "")
+    def _var_access(self, key, type, val=None, default=None):
+        result = default
+        if key in self.vars:
+            result = self.vars[key].value
+        if not val is None:
+            self.vars[key] = Var(type, val)
+        return result
 
-  def start_position(self, val = None, player = 1):
-    """ Returns the starting position of a player as a tuple of floats.
+    def name(self, val=None):
+        """ Returns the level name.
 
-        val - If not None sets the new player position.
-        player - The player ID to set the position of.
-    """
-    result = [0, 0]
-    keys = ["p%d_x" % player, "p%d_y" % player]
-    for (i, key) in enumerate(keys):
-      if key in self.vars:
-        result[i] = self.vars[key].value / 48.0
-      if not val is None:
-        self.vars[key] = Var(VarType.UINT, int(round(val[i] * 48)))
-    return (result[0], result[1])
+            val - If not None sets the new name of the Map.
+        """
+        return self._var_access("level_name", VarType.STRING, val, "")
 
-  def virtual_character(self, val = None):
-    """ Returns True if the map uses virtual characters.
+    def start_position(self, val=None, player=1):
+        """ Returns the starting position of a player as a tuple of floats.
 
-        val - If not None sets the virtual character flag for the map.
-    """
-    return self._var_access("vector_character", VarType.BOOL, val, False)
+            val - If not None sets the new player position.
+            player - The player ID to set the position of.
+        """
+        result = [0, 0]
+        keys = ["p%d_x" % player, "p%d_y" % player]
+        for (i, key) in enumerate(keys):
+            if key in self.vars:
+                result[i] = self.vars[key].value / 48.0
+            if not val is None:
+                self.vars[key] = Var(VarType.UINT, int(round(val[i] * 48)))
+        return (result[0], result[1])
 
-  def add_entity(self, x, y, entity, id = None):
-    """ Adds a new entity to the map and returns its id.
+    def virtual_character(self, val=None):
+        """ Returns True if the map uses virtual characters.
 
-        x - The x position in tile units of the entity.
-        y - The y position in tile units of the entity.
-        entity - The Entity object to add to the map.
-        id - The entity identifier.  If set to None the identifier will be
-             allocated for you.
+            val - If not None sets the virtual character flag for the map.
+        """
+        return self._var_access("vector_character", VarType.BOOL, val, False)
 
-        Raises a MapException if the given id is already in use.
-    """
-    if id is None or id in self.entities:
-      id = self._next_id()
-    else:
-      self._note_id(id)
-    if id in self.entities:
-      raise MapException("map already has id")
-    self.entities[id] = (x, y, entity)
-    return id
+    def add_entity(self, x, y, entity, id=None):
+        """ Adds a new entity to the map and returns its id.
 
-  def add_prop(self, layer, x, y, prop, id = None):
-    """ Adds a new prop to the map and returns its id.
+            x - The x position in tile units of the entity.
+            y - The y position in tile units of the entity.
+            entity - The Entity object to add to the map.
+            id - The entity identifier.  If set to None the identifier will be
+                 allocated for you.
 
-        x - The x position in tile units of the prop.
-        y - The y position in tile units of the prop.
-        prop - The Prop object to add to the map.
-        id - The prop identifier.  If set to None the identifier will be
-             allocated for you.
+            Raises a MapException if the given id is already in use.
+        """
+        if id is None or id in self.entities:
+            id = self._next_id()
+        else:
+            self._note_id(id)
+        if id in self.entities:
+            raise MapException("map already has id")
+        self.entities[id] = (x, y, entity)
+        return id
 
-        Raises a MapException if the given id is already in use.
-    """
-    id = self._next_id()
-    self.props[id] = (layer, x, y, prop)
-    return id
+    def add_prop(self, layer, x, y, prop, id=None):
+        """ Adds a new prop to the map and returns its id.
 
-  def add_tile(self, layer, x, y, tile):
-    """ Adds a new tile to the map.
+            x - The x position in tile units of the prop.
+            y - The y position in tile units of the prop.
+            prop - The Prop object to add to the map.
+            id - The prop identifier.  If set to None the identifier will be
+                 allocated for you.
 
-        layer - The layer to add the tile.
-        x - The x position of the tile.
-        y - The y position of the tile.
-        tile - The tile to add to the map.
+            Raises a MapException if the given id is already in use.
+        """
+        id = self._next_id()
+        self.props[id] = (layer, x, y, prop)
+        return id
 
-        Raises a MapException if the given position is already occupied.
-    """
-    if (layer, x, y) in self.tiles:
-      raise MapException("tile already exists")
-    self.tiles[(layer, x, y)] = tile
+    def add_tile(self, layer, x, y, tile):
+        """ Adds a new tile to the map.
 
-  def get_tile(self, layer, x, y):
-    """ Returns the tile at the given position or None.
+            layer - The layer to add the tile.
+            x - The x position of the tile.
+            y - The y position of the tile.
+            tile - The tile to add to the map.
 
-        layer - The layer to add the tile.
-        x - The x position of the tile.
-        y - The y position of the tile.
-    """
-    return self.tiles.get((layer, x, y), None)
+            Raises a MapException if the given position is already occupied.
+        """
+        if (layer, x, y) in self.tiles:
+            raise MapException("tile already exists")
+        self.tiles[(layer, x, y)] = tile
 
-  def delete_tile(self, layer, x, y):
-    """ Delete the tile at the given position if present.
+    def get_tile(self, layer, x, y):
+        """ Returns the tile at the given position or None.
 
-        layer - The layer to add the tile.
-        x - The x position of the tile.
-        y - The y position of the tile.
-    """
-    if (layer, x, y) in self.tiles:
-      del self.tiles[(layer, x, y)]
+            layer - The layer to add the tile.
+            x - The x position of the tile.
+            y - The y position of the tile.
+        """
+        return self.tiles.get((layer, x, y), None)
 
-  def get_prop(self, id):
-    """ Returns the Prop object with the given id or None. """
-    return self.props.get(id, (None, None, None, None))[3]
+    def delete_tile(self, layer, x, y):
+        """ Delete the tile at the given position if present.
 
-  def get_prop_layer(self, id):
-    """ Returns the layer of the prop with the given id or None. """
-    return self.props.get(id, (None, None, None, None))[0]
+            layer - The layer to add the tile.
+            x - The x position of the tile.
+            y - The y position of the tile.
+        """
+        if (layer, x, y) in self.tiles:
+            del self.tiles[(layer, x, y)]
 
-  def get_prop_xposition(self, id):
-    """ Returns the x position of the prop with the given id or None. """
-    return self.props.get(id, (None, None, None, None))[1]
+    def get_prop(self, id):
+        """ Returns the Prop object with the given id or None. """
+        return self.props.get(id, (None, None, None, None))[3]
 
-  def get_prop_yposition(self, id):
-    """ Returns the y position of the prop with the given id or None. """
-    return self.props.get(id, (None, None, None, None))[2]
+    def get_prop_layer(self, id):
+        """ Returns the layer of the prop with the given id or None. """
+        return self.props.get(id, (None, None, None, None))[0]
 
-  def get_entity(self, id):
-    """ Returns the Entity object with the given id or None. """
-    return self.entities.get(id, (None, None, None))[2]
+    def get_prop_xposition(self, id):
+        """ Returns the x position of the prop with the given id or None. """
+        return self.props.get(id, (None, None, None, None))[1]
 
-  def get_entity_xposition(self, id):
-    """ Returns the x position of the entity with the given id or None. """
-    return self.entities.get(id, (None, None, None))[0]
+    def get_prop_yposition(self, id):
+        """ Returns the y position of the prop with the given id or None. """
+        return self.props.get(id, (None, None, None, None))[2]
 
-  def get_entity_yposition(self, id):
-    """ Returns the y position of the entity with the given id or None. """
-    return self.entities.get(id, (None, None, None))[1]
+    def get_entity(self, id):
+        """ Returns the Entity object with the given id or None. """
+        return self.entities.get(id, (None, None, None))[2]
 
-  def translate(self, x, y):
-    """ Translate the entire map x tiles laterally and y tiles horizontally.
+    def get_entity_xposition(self, id):
+        """ Returns the x position of the entity with the given id or None. """
+        return self.entities.get(id, (None, None, None))[0]
 
-        x - The number of tiles to move laterally.  If a float tiles will be
-            moved by the nearest integer.
-        y - The number of tiles to move horizontally.  If a float tiles will be
-            moved by the nearest integer.
-    """
-    self.transform([[1, 0, x], [0, 1, y], [0, 0, 1]])
+    def get_entity_yposition(self, id):
+        """ Returns the y position of the entity with the given id or None. """
+        return self.entities.get(id, (None, None, None))[1]
 
-  def remap_ids(self, min_id = None):
-    """ Remap prop and entity ids starting at min_id.
+    def translate(self, x, y):
+        """ Translate the entire map x tiles laterally and y tiles horizontally.
 
-        This calls through to all entities to remap any references to other
-        entity ids.
-    """
-    if min_id is None:
-      self._min_id = 100
-    else:
-      self._min_id = min_id
+            x - The number of tiles to move laterally.  If a float tiles will be
+                moved by the nearest integer.
+            y - The number of tiles to move horizontally.  If a float tiles will be
+                moved by the nearest integer.
+        """
+        self.transform([[1, 0, x], [0, 1, y], [0, 0, 1]])
 
-    prop_remap = {}
-    for id in self.props.keys():
-      prop_remap[id] = self._next_id()
-    self.props = {prop_remap[id]: self.props[id] for
-                       id in self.props.keys()}
+    def remap_ids(self, min_id=None):
+        """ Remap prop and entity ids starting at min_id.
 
-    if hasattr(self, "backdrop"):
-      entity_remap = {}
-      for id in self.entities.keys():
-        entity_remap[id] = self._next_id()
-      self.entities = {entity_remap[id]: self.entities[id] for
-                         id in self.entities.keys()}
-      for (x, y, entity) in self.entities.values():
-        entity.remap_ids(entity_remap)
+            This calls through to all entities to remap any references to other
+            entity ids.
+        """
+        if min_id is None:
+            self._min_id = 100
+        else:
+            self._min_id = min_id
 
-      self.backdrop.remap_ids()
+        prop_remap = {}
+        for id in self.props.keys():
+            prop_remap[id] = self._next_id()
+        self.props = {prop_remap[id]: self.props[id] for
+                      id in self.props.keys()}
 
-  def merge_map(self, map, _do_remap_ids = True):
-    """ Merge a map into this one.
+        if hasattr(self, "backdrop"):
+            entity_remap = {}
+            for id in self.entities.keys():
+                entity_remap[id] = self._next_id()
+            self.entities = {entity_remap[id]: self.entities[id] for
+                             id in self.entities.keys()}
+            for (x, y, entity) in self.entities.values():
+                entity.remap_ids(entity_remap)
 
-        map - The Map to merge into this one.
-    """
-    if _do_remap_ids:
-      self.remap_ids(map._min_id)
-    self.tiles.update(copy.deepcopy(map.tiles))
-    self.props.update(copy.deepcopy(map.props))
+            self.backdrop.remap_ids()
 
-    if hasattr(self, "backdrop") and hasattr(map, "backdrop"):
-      self.entities.update(copy.deepcopy(map.entities))
-      self.backdrop.merge_map(map.backdrop, False)
+    def merge_map(self, map, _do_remap_ids=True):
+        """ Merge a map into this one.
 
-  
-  def transform(self, mat):
-    """ Transforms the map with the given affine transformation matrix.  Note
-        that this will probably not produce desirable results if the
-        transformation matrix is not some mixture of a translation, flip,
-        and 90 degree rotations.
+            map - The Map to merge into this one.
+        """
+        if _do_remap_ids:
+            self.remap_ids(map._min_id)
+        self.tiles.update(copy.deepcopy(map.tiles))
+        self.props.update(copy.deepcopy(map.props))
 
-        In most cases you should not use this method directly and instead use
-        Map.flip_horizontal(), Map.flip_vertical(), or Map.rotate().
+        if hasattr(self, "backdrop") and hasattr(map, "backdrop"):
+            self.entities.update(copy.deepcopy(map.entities))
+            self.backdrop.merge_map(map.backdrop, False)
 
-        mat - The affine transformation matrix. [x', y', 1]' = mat * [x, y, 1]'
-    """
-    self.tiles = {(layer, mat[0][2] + x * mat[0][0] + y * mat[0][1] +
-                          min(0, mat[0][0]) + min(0, mat[0][1]),
-                          mat[1][2] + x * mat[1][0] + y * mat[1][1] +
-                          min(0, mat[1][0]) + min(0, mat[1][1])
-                      ): tile for ((layer, x, y), tile) in self.tiles.items()}
-    self.props = {id: (layer, mat[0][2] + x * mat[0][0] + y * mat[0][1],
-                              mat[1][2] + x * mat[1][0] + y * mat[1][1], prop)
-                   for (id, (layer, x, y, prop)) in self.props.items()}
-    for tile in self.tiles.values():
-      tile.transform(mat)
-    for (layer, x, y, prop) in self.props.values():
-      prop.transform(mat)
-    pos = self.start_position()
-    self.start_position((mat[0][2] + pos[0] * mat[0][0] + pos[1] * mat[0][1],
-                         mat[1][2] + pos[0] * mat[1][0] + pos[1] * mat[1][1]))
+    def transform(self, mat):
+        """ Transforms the map with the given affine transformation matrix.  Note
+            that this will probably not produce desirable results if the
+            transformation matrix is not some mixture of a translation, flip,
+            and 90 degree rotations.
 
-    if hasattr(self, "entities"):
-      self.entities = {id: (mat[0][2] + x * mat[0][0] + y * mat[0][1],
-                            mat[1][2] + x * mat[1][0] + y * mat[1][1], entity)
-                     for (id, (x, y, entity)) in self.entities.items()}
-      for (x, y, entity) in self.entities.values():
-        entity.transform(mat)
+            In most cases you should not use this method directly and instead use
+            Map.flip_horizontal(), Map.flip_vertical(), or Map.rotate().
 
-    if hasattr(self, "backdrop"):
-      self.backdrop.transform(mat)
+            mat - The affine transformation matrix. [x', y', 1]' = mat * [x, y, 1]'
+        """
+        self.tiles = {(layer, mat[0][2] + x * mat[0][0] + y * mat[0][1] +
+                       min(0, mat[0][0]) + min(0, mat[0][1]),
+                       mat[1][2] + x * mat[1][0] + y * mat[1][1] +
+                       min(0, mat[1][0]) + min(0, mat[1][1])
+                       ): tile for ((layer, x, y), tile) in self.tiles.items()}
+        self.props = {id: (layer, mat[0][2] + x * mat[0][0] + y * mat[0][1],
+                           mat[1][2] + x * mat[1][0] + y * mat[1][1], prop)
+                      for (id, (layer, x, y, prop)) in self.props.items()}
+        for tile in self.tiles.values():
+            tile.transform(mat)
+        for (layer, x, y, prop) in self.props.values():
+            prop.transform(mat)
+        pos = self.start_position()
+        self.start_position((mat[0][2] + pos[0] * mat[0][0] + pos[1] * mat[0][1],
+                             mat[1][2] + pos[0] * mat[1][0] + pos[1] * mat[1][1]))
 
-  def flip_horizontal(self):
-    """ Flips the map horizontally. """
-    self.transform([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        if hasattr(self, "entities"):
+            self.entities = {id: (mat[0][2] + x * mat[0][0] + y * mat[0][1],
+                                  mat[1][2] + x * mat[1][0] + y * mat[1][1], entity)
+                             for (id, (x, y, entity)) in self.entities.items()}
+            for (x, y, entity) in self.entities.values():
+                entity.transform(mat)
 
-  def flip_vertical(self):
-    """ Flips the map vertically. """
-    self.transform([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
+        if hasattr(self, "backdrop"):
+            self.backdrop.transform(mat)
 
-  def rotate(self, times = 1):
-    """ Rotates the map 90 degrees `times` times.
+    def flip_horizontal(self):
+        """ Flips the map horizontally. """
+        self.transform([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
-    times - The number of 90 degree rotations to perform.  This can be negative.
-    """
-    cs = [1, 0, -1, 0]
-    sn = [0, 1, 0, -1]
-    times %= 4
-    self.transform([[cs[times], -sn[times], 0], [sn[times], cs[times], 0],
-                    [0, 0, 1]])
+    def flip_vertical(self):
+        """ Flips the map vertically. """
+        self.transform([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
+
+    def rotate(self, times=1):
+        """ Rotates the map 90 degrees `times` times.
+
+        times - The number of 90 degree rotations to perform.  This can be negative.
+        """
+        cs = [1, 0, -1, 0]
+        sn = [0, 1, 0, -1]
+        times %= 4
+        self.transform([[cs[times], -sn[times], 0], [sn[times], cs[times], 0],
+                        [0, 0, 1]])

--- a/dustmaker/Map.py
+++ b/dustmaker/Map.py
@@ -1,7 +1,6 @@
+import copy
 from .MapException import MapException
 from .Var import Var, VarType
-
-import copy
 
 
 class Map:
@@ -11,11 +10,11 @@ class Map:
 
         map.tiles - A dict mapping (layer, x, y) to Tile objects.
         map.props - A dict mapping prop ids to Prop objects.
-        map.parent - For backdrops this is the containing map.  Otherwise this is
-                     set to None.
+        map.parent - For backdrops this is the containing map.  Otherwise this
+                     is set to None.
 
-        If the map is not a backdrop (i.e. map.parent == None) then the following
-        attributes will also be available:
+        If the map is not a backdrop (i.e. map.parent == None) then the
+        following attributes will also be available:
 
         map.entities - A dict mapping entity ids to Entity objects.
         map.backdrop - The backdrop Map object.  Backdrop maps can only contain
@@ -30,8 +29,8 @@ class Map:
     def __init__(self, parent=None):
         """ Constructs a blank level object.
 
-            parent - If this Map represents a backdrop this is the containing map.
-                     Typical usage should not need to use this parameter.
+            parent - If this Map represents a backdrop this is the containing
+                     map.  Typical usage should not need to use this parameter.
         """
         self._min_id = 100
         self.tiles = {}
@@ -60,7 +59,7 @@ class Map:
         result = default
         if key in self.vars:
             result = self.vars[key].value
-        if not val is None:
+        if val is not None:
             self.vars[key] = Var(type, val)
         return result
 
@@ -82,7 +81,7 @@ class Map:
         for (i, key) in enumerate(keys):
             if key in self.vars:
                 result[i] = self.vars[key].value / 48.0
-            if not val is None:
+            if val is not None:
                 self.vars[key] = Var(VarType.UINT, int(round(val[i] * 48)))
         return (result[0], result[1])
 
@@ -192,10 +191,10 @@ class Map:
     def translate(self, x, y):
         """ Translate the entire map x tiles laterally and y tiles horizontally.
 
-            x - The number of tiles to move laterally.  If a float tiles will be
-                moved by the nearest integer.
-            y - The number of tiles to move horizontally.  If a float tiles will be
-                moved by the nearest integer.
+            x - The number of tiles to move laterally.  If a float tiles will
+                be moved by the nearest integer.
+            y - The number of tiles to move horizontally.  If a float tiles
+                will be moved by the nearest integer.
         """
         self.transform([[1, 0, x], [0, 1, y], [0, 0, 1]])
 
@@ -247,16 +246,19 @@ class Map:
             transformation matrix is not some mixture of a translation, flip,
             and 90 degree rotations.
 
-            In most cases you should not use this method directly and instead use
-            Map.flip_horizontal(), Map.flip_vertical(), or Map.rotate().
+            In most cases you should not use this method directly and instead
+            use Map.flip_horizontal(), Map.flip_vertical(), or Map.rotate().
 
-            mat - The affine transformation matrix. [x', y', 1]' = mat * [x, y, 1]'
+            mat - The affine transformation matrix.
+                  [x', y', 1]' = mat * [x, y, 1]'
         """
-        self.tiles = {(layer, mat[0][2] + x * mat[0][0] + y * mat[0][1] +
-                       min(0, mat[0][0]) + min(0, mat[0][1]),
-                       mat[1][2] + x * mat[1][0] + y * mat[1][1] +
-                       min(0, mat[1][0]) + min(0, mat[1][1])
-                       ): tile for ((layer, x, y), tile) in self.tiles.items()}
+        self.tiles = {
+            (layer, mat[0][2] + x * mat[0][0] + y * mat[0][1] +
+             min(0, mat[0][0]) + min(0, mat[0][1]),
+             mat[1][2] + x * mat[1][0] + y * mat[1][1] +
+             min(0, mat[1][0]) + min(0, mat[1][1])): tile
+            for ((layer, x, y), tile) in self.tiles.items()
+        }
         self.props = {id: (layer, mat[0][2] + x * mat[0][0] + y * mat[0][1],
                            mat[1][2] + x * mat[1][0] + y * mat[1][1], prop)
                       for (id, (layer, x, y, prop)) in self.props.items()}
@@ -265,13 +267,17 @@ class Map:
         for (layer, x, y, prop) in self.props.values():
             prop.transform(mat)
         pos = self.start_position()
-        self.start_position((mat[0][2] + pos[0] * mat[0][0] + pos[1] * mat[0][1],
-                             mat[1][2] + pos[0] * mat[1][0] + pos[1] * mat[1][1]))
+        self.start_position(
+            (mat[0][2] + pos[0] * mat[0][0] + pos[1] * mat[0][1],
+             mat[1][2] + pos[0] * mat[1][0] + pos[1] * mat[1][1])
+        )
 
         if hasattr(self, "entities"):
-            self.entities = {id: (mat[0][2] + x * mat[0][0] + y * mat[0][1],
-                                  mat[1][2] + x * mat[1][0] + y * mat[1][1], entity)
-                             for (id, (x, y, entity)) in self.entities.items()}
+            self.entities = {
+                id: (mat[0][2] + x * mat[0][0] + y * mat[0][1],
+                     mat[1][2] + x * mat[1][0] + y * mat[1][1], entity)
+                for (id, (x, y, entity)) in self.entities.items()
+            }
             for (x, y, entity) in self.entities.values():
                 entity.transform(mat)
 
@@ -289,7 +295,8 @@ class Map:
     def rotate(self, times=1):
         """ Rotates the map 90 degrees `times` times.
 
-        times - The number of 90 degree rotations to perform.  This can be negative.
+        times - The number of 90 degree rotations to perform.  This can be
+                negative.
         """
         cs = [1, 0, -1, 0]
         sn = [0, 1, 0, -1]

--- a/dustmaker/MapException.py
+++ b/dustmaker/MapException.py
@@ -1,5 +1,6 @@
 class MapException(Exception):
-  pass
+    pass
+
 
 class MapParseException(MapException):
-  pass
+    pass

--- a/dustmaker/MapReader.py
+++ b/dustmaker/MapReader.py
@@ -1,3 +1,4 @@
+import zlib
 from .Map import Map
 from .Tile import Tile, TileShape
 from .Prop import Prop
@@ -5,8 +6,6 @@ from .Entity import Entity
 from .Var import Var, VarType
 from .BitReader import BitReader
 from .MapException import MapParseException
-
-import zlib
 
 
 def _read_expect(reader, data):
@@ -107,6 +106,7 @@ def _read_segment(reader, map, xoffset, yoffset):
     if version > 5:
         tile_surface = reader.read(16)
         dustblock_filth = reader.read(16)
+        pass
 
     flags = reader.read(32)
     if flags & 1:
@@ -131,7 +131,7 @@ def _read_segment(reader, map, xoffset, yoffset):
             ypos = reader.read(5)
             data = reader.read_bytes(12)
             tile = map.get_tile(19, xoffset + xpos, yoffset + ypos)
-            if tile != None:
+            if tile is not None:
                 tile.dust_data = bytearray(data)
 
     if flags & 8:
@@ -153,9 +153,12 @@ def _read_segment(reader, map, xoffset, yoffset):
             prop_index = reader.read(12)
             palette = reader.read(8)
 
-            map.add_prop(layer, xpos / 48, ypos / 48, Prop(
-                         layer_sub, rotation, scale_x, scale_y,
-                         prop_set, prop_group, prop_index, palette), id)
+            map.add_prop(
+                layer, xpos / 48, ypos / 48,
+                Prop(layer_sub, rotation, scale_x, scale_y,
+                     prop_set, prop_group, prop_index, palette),
+                id
+            )
 
     if flags & 4:
         entities = reader.read(16)
@@ -174,8 +177,12 @@ def _read_segment(reader, map, xoffset, yoffset):
             unk4 = reader.read(1)
             vars = _read_var_map(reader)
 
-            map.add_entity(xpos / 48, ypos / 48, Entity._from_raw(
-                           type, vars, rotation, layer, unk2, unk3, unk4), id)
+            map.add_entity(
+                xpos / 48, ypos / 48,
+                Entity._from_raw(type, vars, rotation,
+                                 layer, unk2, unk3, unk4),
+                id
+            )
 
 
 def _read_region(reader, map):

--- a/dustmaker/MapReader.py
+++ b/dustmaker/MapReader.py
@@ -8,232 +8,247 @@ from .MapException import MapParseException
 
 import zlib
 
+
 def _read_expect(reader, data):
-  for x in data:
-    if x != reader.read(8):
-      raise MapParseException("unexpected data")
+    for x in data:
+        if x != reader.read(8):
+            raise MapParseException("unexpected data")
+
 
 def _read_float(reader, ibits, fbits):
-  sign = 1 - 2 * reader.read(1)
-  ipart = reader.read(ibits - 1)
-  fpart = reader.read(fbits)
-  return sign * ipart + 1.0 * fpart / (1 << (fbits - 1))
+    sign = 1 - 2 * reader.read(1)
+    ipart = reader.read(ibits - 1)
+    fpart = reader.read(fbits)
+    return sign * ipart + 1.0 * fpart / (1 << (fbits - 1))
+
 
 def _read_6bit_str(reader):
-  len = reader.read(6)
-  chrs = []
-  for i in range(len):
-    v = reader.read(6)
-    if v < 10:
-      chrs.append(chr(ord('0') + v))
-    elif v < 36:
-      chrs.append(chr(ord('A') + v - 10))
-    elif v == 36:
-      chrs.append('_')
-    elif v < 63:
-      chrs.append(chr(ord('a') + v - 37))
-    else:
-      chrs.append('{')
-  return ''.join(chrs)
-
-def _read_var_type(reader, type):
-  if type == VarType.NULL: return None
-  if type == VarType.BOOL: return reader.read(1) == 1
-  if type == VarType.UINT: return reader.read(32)
-  if type == VarType.INT: return reader.read(32, True)
-  if type == VarType.FLOAT: return _read_float(reader, 32, 32)
-
-  if type == VarType.STRING:
+    len = reader.read(6)
     chrs = []
-    slen = reader.read(16)
-    for i in range(slen):
-      chrs.append(chr(reader.read(8)))
+    for i in range(len):
+        v = reader.read(6)
+        if v < 10:
+            chrs.append(chr(ord('0') + v))
+        elif v < 36:
+            chrs.append(chr(ord('A') + v - 10))
+        elif v == 36:
+            chrs.append('_')
+        elif v < 63:
+            chrs.append(chr(ord('a') + v - 37))
+        else:
+            chrs.append('{')
     return ''.join(chrs)
 
-  if type == VarType.VEC2:
-    f0 = _read_float(reader, 32, 32)
-    f1 = _read_float(reader, 32, 32)
-    return (f0, f1)
 
-  if type == VarType.ARRAY:
-    atype = VarType(reader.read(4))
-    alen = reader.read(16)
-    val = []
-    for i in range(alen):
-      val.append(Var(atype, _read_var_type(reader, atype)))
-    return (atype, val)
+def _read_var_type(reader, type):
+    if type == VarType.NULL:
+        return None
+    if type == VarType.BOOL:
+        return reader.read(1) == 1
+    if type == VarType.UINT:
+        return reader.read(32)
+    if type == VarType.INT:
+        return reader.read(32, True)
+    if type == VarType.FLOAT:
+        return _read_float(reader, 32, 32)
 
-  raise MapParseException("unknown var type")
+    if type == VarType.STRING:
+        chrs = []
+        slen = reader.read(16)
+        for i in range(slen):
+            chrs.append(chr(reader.read(8)))
+        return ''.join(chrs)
+
+    if type == VarType.VEC2:
+        f0 = _read_float(reader, 32, 32)
+        f1 = _read_float(reader, 32, 32)
+        return (f0, f1)
+
+    if type == VarType.ARRAY:
+        atype = VarType(reader.read(4))
+        alen = reader.read(16)
+        val = []
+        for i in range(alen):
+            val.append(Var(atype, _read_var_type(reader, atype)))
+        return (atype, val)
+
+    raise MapParseException("unknown var type")
+
 
 def _read_var(reader):
-  type = VarType(reader.read(4))
-  if type == VarType.NULL:
-    return None
+    type = VarType(reader.read(4))
+    if type == VarType.NULL:
+        return None
 
-  str = _read_6bit_str(reader)
-  return (str, Var(type, _read_var_type(reader, type)))
+    str = _read_6bit_str(reader)
+    return (str, Var(type, _read_var_type(reader, type)))
+
 
 def _read_var_map(reader):
-  result = {}
-  while True:
-    var = _read_var(reader)
-    if var is None:
-      return result
-    result[var[0]] = var[1]
+    result = {}
+    while True:
+        var = _read_var(reader)
+        if var is None:
+            return result
+        result[var[0]] = var[1]
+
 
 def _read_segment(reader, map, xoffset, yoffset):
-  segment_size = reader.read(32)
-  version = reader.read(16)
-  xoffset += reader.read(8) * 16
-  yoffset += reader.read(8) * 16
-  unk1 = reader.read(8)
+    segment_size = reader.read(32)
+    version = reader.read(16)
+    xoffset += reader.read(8) * 16
+    yoffset += reader.read(8) * 16
+    unk1 = reader.read(8)
 
-  if version > 4:
-    unk2 = reader.read(32)
-    dust_filth = reader.read(16)
-    enemy_filth = reader.read(16)
-  if version > 5:
-    tile_surface = reader.read(16)
-    dustblock_filth = reader.read(16)
+    if version > 4:
+        unk2 = reader.read(32)
+        dust_filth = reader.read(16)
+        enemy_filth = reader.read(16)
+    if version > 5:
+        tile_surface = reader.read(16)
+        dustblock_filth = reader.read(16)
 
-  flags = reader.read(32)
-  if flags & 1:
-    layers = reader.read(8)
-    for i in range(layers):
-      layer = reader.read(8)
-      tiles = reader.read(10)
+    flags = reader.read(32)
+    if flags & 1:
+        layers = reader.read(8)
+        for i in range(layers):
+            layer = reader.read(8)
+            tiles = reader.read(10)
 
-      for j in range(tiles):
-        xpos = reader.read(5)
-        ypos = reader.read(5)
-        shape = reader.read(8)
-        data = reader.read_bytes(12)
-        if shape & 0x80:
-          map.add_tile(layer, xoffset + xpos, yoffset + ypos,
-                       Tile(TileShape(shape & 0x1F), data))
+            for j in range(tiles):
+                xpos = reader.read(5)
+                ypos = reader.read(5)
+                shape = reader.read(8)
+                data = reader.read_bytes(12)
+                if shape & 0x80:
+                    map.add_tile(layer, xoffset + xpos, yoffset + ypos,
+                                 Tile(TileShape(shape & 0x1F), data))
 
-  if flags & 2:
-    dusts = reader.read(10)
-    for i in range(dusts):
-      xpos = reader.read(5)
-      ypos = reader.read(5)
-      data = reader.read_bytes(12)
-      tile = map.get_tile(19, xoffset + xpos, yoffset + ypos)
-      if tile != None:
-        tile.dust_data = bytearray(data)
+    if flags & 2:
+        dusts = reader.read(10)
+        for i in range(dusts):
+            xpos = reader.read(5)
+            ypos = reader.read(5)
+            data = reader.read_bytes(12)
+            tile = map.get_tile(19, xoffset + xpos, yoffset + ypos)
+            if tile != None:
+                tile.dust_data = bytearray(data)
 
-  if flags & 8:
-    props = reader.read(16)
-    for i in range(props):
-      id = reader.read(32, True)
-      if id < 0:
-        continue
+    if flags & 8:
+        props = reader.read(16)
+        for i in range(props):
+            id = reader.read(32, True)
+            if id < 0:
+                continue
 
-      layer = reader.read(8)
-      layer_sub = reader.read(8)
-      xpos = _read_float(reader, 28, 4)
-      ypos = _read_float(reader, 28, 4)
-      rotation = reader.read(16)
-      scale_x = reader.read(1) == 1
-      scale_y = reader.read(1) == 1
-      prop_set = reader.read(8)
-      prop_group = reader.read(12)
-      prop_index = reader.read(12)
-      palette = reader.read(8)
+            layer = reader.read(8)
+            layer_sub = reader.read(8)
+            xpos = _read_float(reader, 28, 4)
+            ypos = _read_float(reader, 28, 4)
+            rotation = reader.read(16)
+            scale_x = reader.read(1) == 1
+            scale_y = reader.read(1) == 1
+            prop_set = reader.read(8)
+            prop_group = reader.read(12)
+            prop_index = reader.read(12)
+            palette = reader.read(8)
 
-      map.add_prop(layer, xpos / 48, ypos / 48, Prop(
-                   layer_sub, rotation, scale_x, scale_y,
-                   prop_set, prop_group, prop_index, palette), id)
+            map.add_prop(layer, xpos / 48, ypos / 48, Prop(
+                         layer_sub, rotation, scale_x, scale_y,
+                         prop_set, prop_group, prop_index, palette), id)
 
-  if flags & 4:
-    entities = reader.read(16)
-    for i in range(entities):
-      id = reader.read(32, True)
-      if id < 0:
-        continue
+    if flags & 4:
+        entities = reader.read(16)
+        for i in range(entities):
+            id = reader.read(32, True)
+            if id < 0:
+                continue
 
-      type = _read_6bit_str(reader)
-      xpos = _read_float(reader, 32, 8)
-      ypos = _read_float(reader, 32, 8)
-      rotation = reader.read(16)
-      layer = reader.read(8)
-      unk2 = reader.read(1)
-      unk3 = reader.read(1)
-      unk4 = reader.read(1)
-      vars = _read_var_map(reader)
+            type = _read_6bit_str(reader)
+            xpos = _read_float(reader, 32, 8)
+            ypos = _read_float(reader, 32, 8)
+            rotation = reader.read(16)
+            layer = reader.read(8)
+            unk2 = reader.read(1)
+            unk3 = reader.read(1)
+            unk4 = reader.read(1)
+            vars = _read_var_map(reader)
 
-      map.add_entity(xpos / 48, ypos / 48, Entity._from_raw(
-                     type, vars, rotation, layer, unk2, unk3, unk4), id)
+            map.add_entity(xpos / 48, ypos / 48, Entity._from_raw(
+                           type, vars, rotation, layer, unk2, unk3, unk4), id)
+
 
 def _read_region(reader, map):
-  region_len = reader.read(32)
-  uncompressed_len = reader.read(32)
-  offx = reader.read(16, True)
-  offy = reader.read(16, True)
-  unk4 = reader.read(16)
-  segments = reader.read(16)
-  has_backdrop = reader.read(8) != 0
+    region_len = reader.read(32)
+    uncompressed_len = reader.read(32)
+    offx = reader.read(16, True)
+    offy = reader.read(16, True)
+    unk4 = reader.read(16)
+    segments = reader.read(16)
+    has_backdrop = reader.read(8) != 0
 
-  reader = BitReader(zlib.decompress(reader.read_bytes(region_len - 17)))
-  for i in range(segments):
-    reader.align(8)
-    _read_segment(reader, map, offx * 256, offy * 256)
+    reader = BitReader(zlib.decompress(reader.read_bytes(region_len - 17)))
+    for i in range(segments):
+        reader.align(8)
+        _read_segment(reader, map, offx * 256, offy * 256)
 
-  if has_backdrop:
-    reader.align(8)
-    _read_segment(reader, map.backdrop, offx * 16, offy * 16)
+    if has_backdrop:
+        reader.align(8)
+        _read_segment(reader, map.backdrop, offx * 16, offy * 16)
+
 
 def _read_metadata(reader):
-  _read_expect(reader, b"DF_MTD")
-
-  version = reader.read(16)
-  region_offset = reader.read(32)
-  unk1 = reader.read(32)
-  unk2 = reader.read(32)
-  unk3 = reader.read(32)
-  unk4 = reader.read(32)
-  return {
-    'version': version,
-    'unk1': unk1,
-    'unk2': unk2,
-    'unk3': unk3,
-    'unk4': unk4,
-  }
-
-def read_map(data):
-  """ Returns a Map object parsed from `data` in the Dustforce level format.
-
-      data - A sequence of bytes representing a Dustforce level.
-
-      On error raises a MapParseException.
-  """
-  try:
-    reader = BitReader(data)
-    _read_expect(reader, b"DF_LVL")
+    _read_expect(reader, b"DF_MTD")
 
     version = reader.read(16)
-    if version <= 42:
-      raise MapParseException("unsupported level version")
+    region_offset = reader.read(32)
+    unk1 = reader.read(32)
+    unk2 = reader.read(32)
+    unk3 = reader.read(32)
+    unk4 = reader.read(32)
+    return {
+        'version': version,
+        'unk1': unk1,
+        'unk2': unk2,
+        'unk3': unk3,
+        'unk4': unk4,
+    }
 
-    filesize = reader.read(32)
-    num_regions = reader.read(32)
-    meta = _read_metadata(reader)
 
-    sshot_data = b""
-    if version > 43:
-      sshot_len = reader.read(32)
-      sshot_data = reader.read_bytes(sshot_len)
+def read_map(data):
+    """ Returns a Map object parsed from `data` in the Dustforce level format.
 
-    map = Map()
-    map.vars = _read_var_map(reader)
-    map.sshot = sshot_data
+        data - A sequence of bytes representing a Dustforce level.
 
-    reader.align(8)
-    reader.skip(num_regions * 32)
-    while reader.more():
-      _read_region(reader, map)
-    return map
-  except MapParseException as e:
-    raise e
-  except Exception as e:
-    raise MapParseException(e)
+        On error raises a MapParseException.
+    """
+    try:
+        reader = BitReader(data)
+        _read_expect(reader, b"DF_LVL")
+
+        version = reader.read(16)
+        if version <= 42:
+            raise MapParseException("unsupported level version")
+
+        filesize = reader.read(32)
+        num_regions = reader.read(32)
+        meta = _read_metadata(reader)
+
+        sshot_data = b""
+        if version > 43:
+            sshot_len = reader.read(32)
+            sshot_data = reader.read_bytes(sshot_len)
+
+        map = Map()
+        map.vars = _read_var_map(reader)
+        map.sshot = sshot_data
+
+        reader.align(8)
+        reader.skip(num_regions * 32)
+        while reader.more():
+            _read_region(reader, map)
+        return map
+    except MapParseException as e:
+        raise e
+    except Exception as e:
+        raise MapParseException(e)

--- a/dustmaker/MapWriter.py
+++ b/dustmaker/MapWriter.py
@@ -9,315 +9,336 @@ from .MapException import MapParseException
 import zlib
 from math import floor
 
+
 def _write_float(writer, ibits, fbits, val):
-  ipart = abs(floor(val))
-  fpart = int((val - floor(val)) * (2 ** (fbits - 1)))
-  writer.write(1, 1 if val < 0  else 0)
-  writer.write(ibits - 1, ipart)
-  writer.write(fbits, fpart)
+    ipart = abs(floor(val))
+    fpart = int((val - floor(val)) * (2 ** (fbits - 1)))
+    writer.write(1, 1 if val < 0 else 0)
+    writer.write(ibits - 1, ipart)
+    writer.write(fbits, fpart)
+
 
 def _write_6bit_str(writer, str):
-  writer.write(6, len(str))
-  for ch in str:
-    v = ord(ch)
-    if ord('0') <= v and v <= ord('9'):
-      writer.write(6, v - ord('0'))
-    elif ord('A') <= v and v <= ord('Z'):
-      writer.write(6, v - ord('A') + 10)
-    elif ord('a') <= v and v <= ord('z'):
-      writer.write(6, v - ord('a') + 37)
-    elif ch == '_':
-      writer.write(6, 36)
-    else:
-      writer.write(6, 63)
+    writer.write(6, len(str))
+    for ch in str:
+        v = ord(ch)
+        if ord('0') <= v and v <= ord('9'):
+            writer.write(6, v - ord('0'))
+        elif ord('A') <= v and v <= ord('Z'):
+            writer.write(6, v - ord('A') + 10)
+        elif ord('a') <= v and v <= ord('z'):
+            writer.write(6, v - ord('a') + 37)
+        elif ch == '_':
+            writer.write(6, 36)
+        else:
+            writer.write(6, 63)
+
 
 def _write_var_type(writer, var):
-  type = var.type
-  value = var.value
-  if type == VarType.NULL: return
-  if type == VarType.BOOL: return writer.write(1, 1 if value else 0)
-  if type == VarType.UINT: return writer.write(32, value)
-  if type == VarType.INT: return writer.write(32, value)
-  if type == VarType.FLOAT: return _write_float(writer, 32, 32, value)
+    type = var.type
+    value = var.value
+    if type == VarType.NULL:
+        return
+    if type == VarType.BOOL:
+        return writer.write(1, 1 if value else 0)
+    if type == VarType.UINT:
+        return writer.write(32, value)
+    if type == VarType.INT:
+        return writer.write(32, value)
+    if type == VarType.FLOAT:
+        return _write_float(writer, 32, 32, value)
 
-  if type == VarType.STRING:
-    writer.write(16, len(value))
-    for ch in value:
-      writer.write(8, ord(ch))
-    return
+    if type == VarType.STRING:
+        writer.write(16, len(value))
+        for ch in value:
+            writer.write(8, ord(ch))
+        return
 
-  if type == VarType.VEC2:
-    _write_float(writer, 32, 32, value[0])
-    _write_float(writer, 32, 32, value[1])
-    return
+    if type == VarType.VEC2:
+        _write_float(writer, 32, 32, value[0])
+        _write_float(writer, 32, 32, value[1])
+        return
 
-  if type == VarType.ARRAY:
-    atype = value[0]
-    arr = value[1]
-    writer.write(4, atype)
-    writer.write(16, len(arr))
-    for x in arr:
-      _write_var_type(writer, x)
-    return
+    if type == VarType.ARRAY:
+        atype = value[0]
+        arr = value[1]
+        writer.write(4, atype)
+        writer.write(16, len(arr))
+        for x in arr:
+            _write_var_type(writer, x)
+        return
 
-  raise MapParseException("unknown var type")
+    raise MapParseException("unknown var type")
+
 
 def _write_var(writer, key, var):
-  writer.write(4, var.type)
-  _write_6bit_str(writer, key)
-  _write_var_type(writer, var)
+    writer.write(4, var.type)
+    _write_6bit_str(writer, key)
+    _write_var_type(writer, var)
+
 
 def _write_var_map(writer, vars):
-  for key in vars:
-    _write_var(writer, key, vars[key])
-  writer.write(4, VarType.NULL)
+    for key in vars:
+        _write_var(writer, key, vars[key])
+    writer.write(4, VarType.NULL)
+
 
 def _write_segment(base_writer, seg_x, seg_y, segment):
-  writer = BitWriter()
+    writer = BitWriter()
 
-  flags = 0
-  tiles = [(i, segment['tiles'][i]) for i in range(21) if segment['tiles'][i]]
+    flags = 0
+    tiles = [(i, segment['tiles'][i])
+             for i in range(21) if segment['tiles'][i]]
 
-  (dust_filth, enemy_filth, tile_surface, dustblock_filth) = (0, 0, 0, 0)
+    (dust_filth, enemy_filth, tile_surface, dustblock_filth) = (0, 0, 0, 0)
 
-  dusts = []
-  if tiles:
-    flags |= 1
+    dusts = []
+    if tiles:
+        flags |= 1
 
-    writer.write(8, len(tiles))
-    for (layer, tilelayer) in tiles:
-      writer.write(8, layer)
-      writer.write(10, len(tilelayer))
+        writer.write(8, len(tiles))
+        for (layer, tilelayer) in tiles:
+            writer.write(8, layer)
+            writer.write(10, len(tilelayer))
 
-      for (x, y, tile) in sorted(tilelayer, key = lambda x: (x[1], x[0])):
-        if layer == 19 and tile.has_filth():
-          dusts.append((x, y, tile))
-        if layer == 19:
-          if tile.is_dustblock():
-            dustblock_filth += 1
-          for side in TileSide:
-            edge = tile.edge_filth_sprite(side)
-            if edge[0] != TileSpriteSet.none_0 and not edge[1]:
-              dust_filth += 1
-            if ((tile.edge_bits(side) & 0x3) == 0x3 and
-                not tile.edge_filth_sprite(side)[1]):
-              tile_surface += 1
-        writer.write(5, x)
-        writer.write(5, y)
-        writer.write(8, tile.shape | 0x80)
+            for (x, y, tile) in sorted(tilelayer, key=lambda x: (x[1], x[0])):
+                if layer == 19 and tile.has_filth():
+                    dusts.append((x, y, tile))
+                if layer == 19:
+                    if tile.is_dustblock():
+                        dustblock_filth += 1
+                    for side in TileSide:
+                        edge = tile.edge_filth_sprite(side)
+                        if edge[0] != TileSpriteSet.none_0 and not edge[1]:
+                            dust_filth += 1
+                        if ((tile.edge_bits(side) & 0x3) == 0x3 and
+                                not tile.edge_filth_sprite(side)[1]):
+                            tile_surface += 1
+                writer.write(5, x)
+                writer.write(5, y)
+                writer.write(8, tile.shape | 0x80)
 
-        if len(tile.tile_data) != 12:
-          raise MapParseException("invalid tile data")
-        writer.write_bytes(tile.tile_data)
+                if len(tile.tile_data) != 12:
+                    raise MapParseException("invalid tile data")
+                writer.write_bytes(tile.tile_data)
 
-  if dusts:
-    flags |= 2
+    if dusts:
+        flags |= 2
 
-    writer.write(10, len(dusts))
-    for (x, y, tile) in dusts:
-      writer.write(5, x)
-      writer.write(5, y)
+        writer.write(10, len(dusts))
+        for (x, y, tile) in dusts:
+            writer.write(5, x)
+            writer.write(5, y)
 
-      if len(tile.dust_data) != 12:
-        raise MapParseException("invalid dust data")
-      writer.write_bytes(tile.dust_data)
+            if len(tile.dust_data) != 12:
+                raise MapParseException("invalid dust data")
+            writer.write_bytes(tile.dust_data)
 
-  if segment['props']:
-    flags |= 8
+    if segment['props']:
+        flags |= 8
 
-    writer.write(16, len(segment['props']))
-    for (id, layer, x, y, prop) in segment['props']:
-      writer.write(32, id)
-      writer.write(8, layer)
-      writer.write(8, prop.layer_sub)
-      _write_float(writer, 28, 4, x * 48)
-      _write_float(writer, 28, 4, y * 48)
-      writer.write(16, prop.rotation)
-      writer.write(1, 1 if prop.scale_x else 0)
-      writer.write(1, 1 if prop.scale_y else 0)
-      writer.write(8, prop.prop_set)
-      writer.write(12, prop.prop_group)
-      writer.write(12, prop.prop_index)
-      writer.write(8, prop.palette)
+        writer.write(16, len(segment['props']))
+        for (id, layer, x, y, prop) in segment['props']:
+            writer.write(32, id)
+            writer.write(8, layer)
+            writer.write(8, prop.layer_sub)
+            _write_float(writer, 28, 4, x * 48)
+            _write_float(writer, 28, 4, y * 48)
+            writer.write(16, prop.rotation)
+            writer.write(1, 1 if prop.scale_x else 0)
+            writer.write(1, 1 if prop.scale_y else 0)
+            writer.write(8, prop.prop_set)
+            writer.write(12, prop.prop_group)
+            writer.write(12, prop.prop_index)
+            writer.write(8, prop.palette)
 
-  if segment['entities']:
-    flags |= 4
+    if segment['entities']:
+        flags |= 4
 
-    writer.write(16, len(segment['entities']))
-    for (id, x, y, entity) in segment['entities']:
-      if isinstance(entity, Enemy):
-        enemy_filth += entity.filth()
-      writer.write(32, id)
-      _write_6bit_str(writer, entity.type)
-      _write_float(writer, 32, 8, x * 48)
-      _write_float(writer, 32, 8, y * 48)
-      writer.write(16, entity.rotation)
-      writer.write(8, entity.layer)
-      writer.write(1, entity.unk2)
-      writer.write(1, entity.unk3)
-      writer.write(1, entity.unk4)
-      _write_var_map(writer, entity.vars)
+        writer.write(16, len(segment['entities']))
+        for (id, x, y, entity) in segment['entities']:
+            if isinstance(entity, Enemy):
+                enemy_filth += entity.filth()
+            writer.write(32, id)
+            _write_6bit_str(writer, entity.type)
+            _write_float(writer, 32, 8, x * 48)
+            _write_float(writer, 32, 8, y * 48)
+            writer.write(16, entity.rotation)
+            writer.write(8, entity.layer)
+            writer.write(1, entity.unk2)
+            writer.write(1, entity.unk3)
+            writer.write(1, entity.unk4)
+            _write_var_map(writer, entity.vars)
 
-  writer_body = writer
-  writer = base_writer
+    writer_body = writer
+    writer = base_writer
 
-  writer.write(32, 25 + writer_body.byte_count())
-  writer.write(16, 6)
-  writer.write(8, seg_x)
-  writer.write(8, seg_y)
-  writer.write(8, 16)
+    writer.write(32, 25 + writer_body.byte_count())
+    writer.write(16, 6)
+    writer.write(8, seg_x)
+    writer.write(8, seg_y)
+    writer.write(8, 16)
 
-  writer.write(32, 0)
-  writer.write(16, dust_filth)
-  writer.write(16, enemy_filth)
+    writer.write(32, 0)
+    writer.write(16, dust_filth)
+    writer.write(16, enemy_filth)
 
-  writer.write(16, tile_surface)
-  writer.write(16, dustblock_filth)
+    writer.write(16, tile_surface)
+    writer.write(16, dustblock_filth)
 
-  writer.write(32, flags)
-  writer.write_bytes(writer_body.bytes())
+    writer.write(32, flags)
+    writer.write_bytes(writer_body.bytes())
+
 
 def _write_region(x, y, region):
-  writer = BitWriter()
-  for coord in sorted(region['segments'].keys()):
-    writer.align(8)
-    _write_segment(writer, coord[0], coord[1], region['segments'][coord])
-  if region['backdrop']['present']:
-    writer.align(8)
-    _write_segment(writer, 0, 0, region['backdrop'])
+    writer = BitWriter()
+    for coord in sorted(region['segments'].keys()):
+        writer.align(8)
+        _write_segment(writer, coord[0], coord[1], region['segments'][coord])
+    if region['backdrop']['present']:
+        writer.align(8)
+        _write_segment(writer, 0, 0, region['backdrop'])
 
-  data = zlib.compress(writer.bytes())
+    data = zlib.compress(writer.bytes())
 
-  writer_header = BitWriter()
-  writer_header.write(32, writer.byte_count())
-  writer_header.write(16, x)
-  writer_header.write(16, y)
-  writer_header.write(16, 14)
-  writer_header.write(16, len(region['segments']))
-  writer_header.write(8, 1 if region['backdrop']['present'] else 0)
+    writer_header = BitWriter()
+    writer_header.write(32, writer.byte_count())
+    writer_header.write(16, x)
+    writer_header.write(16, y)
+    writer_header.write(16, 14)
+    writer_header.write(16, len(region['segments']))
+    writer_header.write(8, 1 if region['backdrop']['present'] else 0)
 
-  return b"".join([writer_header.bytes(), data])
+    return b"".join([writer_header.bytes(), data])
+
 
 def _segment_get(segment_map, x, y):
-  sx = int(floor(x / 16)) & 0xF
-  sy = int(floor(y / 16)) & 0xF
-  if (sx, sy) in segment_map:
-    return segment_map[(sx, sy)]
+    sx = int(floor(x / 16)) & 0xF
+    sy = int(floor(y / 16)) & 0xF
+    if (sx, sy) in segment_map:
+        return segment_map[(sx, sy)]
 
-  seg = dict(
-    tiles = [[] for x in range(21)],
-    entities = [],
-    props = [],
-  )
-  segment_map[(sx, sy)] = seg
-  return seg
+    seg = dict(
+        tiles=[[] for x in range(21)],
+        entities=[],
+        props=[],
+    )
+    segment_map[(sx, sy)] = seg
+    return seg
+
 
 def _region_get(region_map, x, y):
-  rx = int(floor(x / 256))
-  ry = int(floor(y / 256))
-  if (rx, ry) in region_map:
-    return region_map[(rx, ry)]
+    rx = int(floor(x / 256))
+    ry = int(floor(y / 256))
+    if (rx, ry) in region_map:
+        return region_map[(rx, ry)]
 
-  reg = dict(
-    segments = {},
-    backdrop = dict(
-      present = False,
-      tiles = [[] for x in range(21)],
-      entities = [],
-      props = [],
+    reg = dict(
+        segments={},
+        backdrop=dict(
+            present=False,
+            tiles=[[] for x in range(21)],
+            entities=[],
+            props=[],
+        )
     )
-  )
-  region_map[(rx, ry)] = reg
-  return reg
+    region_map[(rx, ry)] = reg
+    return reg
+
 
 def _compute_region_map(map):
-  region_map = {}
-  for (coord, tile) in map.tiles.items():
-    layer = coord[0]
-    x = coord[1]
-    y = coord[2]
-    seg = _segment_get(_region_get(region_map, x, y)['segments'], x, y)
-    seg['tiles'][layer].append((x & 0xF, y & 0xF, tile))
+    region_map = {}
+    for (coord, tile) in map.tiles.items():
+        layer = coord[0]
+        x = coord[1]
+        y = coord[2]
+        seg = _segment_get(_region_get(region_map, x, y)['segments'], x, y)
+        seg['tiles'][layer].append((x & 0xF, y & 0xF, tile))
 
-  for id in map.entities.keys():
-    x = map.get_entity_xposition(id)
-    y = map.get_entity_yposition(id)
-    seg = _segment_get(_region_get(region_map, x, y)['segments'], x, y)
-    seg['entities'].append((id, x, y, map.get_entity(id)))
+    for id in map.entities.keys():
+        x = map.get_entity_xposition(id)
+        y = map.get_entity_yposition(id)
+        seg = _segment_get(_region_get(region_map, x, y)['segments'], x, y)
+        seg['entities'].append((id, x, y, map.get_entity(id)))
 
-  for id in map.props.keys():
-    x = map.get_prop_xposition(id)
-    y = map.get_prop_yposition(id)
-    layer = map.get_prop_layer(id)
-    seg = _segment_get(_region_get(region_map, x, y)['segments'], x, y)
-    seg['props'].append((id, layer, x, y, map.get_prop(id)))
+    for id in map.props.keys():
+        x = map.get_prop_xposition(id)
+        y = map.get_prop_yposition(id)
+        layer = map.get_prop_layer(id)
+        seg = _segment_get(_region_get(region_map, x, y)['segments'], x, y)
+        seg['props'].append((id, layer, x, y, map.get_prop(id)))
 
-  if map.backdrop:
-    for (coord, tile) in map.backdrop.tiles.items():
-      layer = coord[0]
-      x = coord[1]
-      y = coord[2]
-      seg = _region_get(region_map, x * 16, y * 16)['backdrop']
-      seg['present'] = True
-      seg['tiles'][layer].append((x & 0xF, y & 0xF, tile))
+    if map.backdrop:
+        for (coord, tile) in map.backdrop.tiles.items():
+            layer = coord[0]
+            x = coord[1]
+            y = coord[2]
+            seg = _region_get(region_map, x * 16, y * 16)['backdrop']
+            seg['present'] = True
+            seg['tiles'][layer].append((x & 0xF, y & 0xF, tile))
 
-    for id in map.backdrop.props.keys():
-      x = map.backdrop.get_prop_xposition(id)
-      y = map.backdrop.get_prop_yposition(id)
-      layer = map.backdrop.get_prop_layer(id)
-      seg = _region_get(region_map, x, y)['backdrop']
-      seg['present'] = True
-      seg['props'].append((id, layer, x, y, map.backdrop.get_prop(id)))
-  return region_map
+        for id in map.backdrop.props.keys():
+            x = map.backdrop.get_prop_xposition(id)
+            y = map.backdrop.get_prop_yposition(id)
+            layer = map.backdrop.get_prop_layer(id)
+            seg = _region_get(region_map, x, y)['backdrop']
+            seg['present'] = True
+            seg['props'].append((id, layer, x, y, map.backdrop.get_prop(id)))
+    return region_map
+
 
 def _write_metadata(writer, var_size, map):
-  writer.write_bytes(b"DF_MTD")
-  writer.write(16, 4)
-  writer.write(32, var_size + 32 + len(map.sshot))
-  writer.write(32, 0)
-  writer.write(32, 0)
-  writer.write(32, 0)
-  writer.write(32, 0)
+    writer.write_bytes(b"DF_MTD")
+    writer.write(16, 4)
+    writer.write(32, var_size + 32 + len(map.sshot))
+    writer.write(32, 0)
+    writer.write(32, 0)
+    writer.write(32, 0)
+    writer.write(32, 0)
+
 
 def _norm_for_sort(coord):
-  x = coord[0]
-  y = coord[1]
-  if x < 0: x += 1 << 16
-  if y < 0: y += 1 << 16
-  return (x, y)
+    x = coord[0]
+    y = coord[1]
+    if x < 0:
+        x += 1 << 16
+    if y < 0:
+        y += 1 << 16
+    return (x, y)
+
 
 def write_map(map):
-  """ Writes a Map object into a sequence of bytes in the Dustforce level
-      format.
+    """ Writes a Map object into a sequence of bytes in the Dustforce level
+        format.
 
-      Returns a bytes object representing the level.
+        Returns a bytes object representing the level.
 
-      On error raises a MapException.
-  """
-  writer_front = BitWriter()
-  _write_var_map(writer_front, map.vars)
-  var_size = writer_front.byte_count()
+        On error raises a MapException.
+    """
+    writer_front = BitWriter()
+    _write_var_map(writer_front, map.vars)
+    var_size = writer_front.byte_count()
 
-  writer_back = BitWriter()
-  region_map = _compute_region_map(map)
-  for coord in sorted(region_map.keys(), key = _norm_for_sort):
-    writer_back.align(8)
-    writer_front.write(32, writer_back.byte_count())
-    reg_data = _write_region(coord[0], coord[1], region_map[coord])
-    writer_back.write(32, len(reg_data) + 4)
-    writer_back.write_bytes(reg_data)
+    writer_back = BitWriter()
+    region_map = _compute_region_map(map)
+    for coord in sorted(region_map.keys(), key=_norm_for_sort):
+        writer_back.align(8)
+        writer_front.write(32, writer_back.byte_count())
+        reg_data = _write_region(coord[0], coord[1], region_map[coord])
+        writer_back.write(32, len(reg_data) + 4)
+        writer_back.write_bytes(reg_data)
 
-  writer_header = BitWriter()
-  writer_header.write(32, len(region_map))
-  _write_metadata(writer_header, var_size, map)
-  writer_header.write(32, len(map.sshot))
-  writer_header.write_bytes(map.sshot)
+    writer_header = BitWriter()
+    writer_header.write(32, len(region_map))
+    _write_metadata(writer_header, var_size, map)
+    writer_header.write(32, len(map.sshot))
+    writer_header.write_bytes(map.sshot)
 
-  writer = BitWriter()
-  writer.write_bytes(b"DF_LVL")
-  writer.write(16, 44)
-  writer.write(32, 12 + len(writer_header.bytes()) +
-                        len(writer_front.bytes()) +
-                        len(writer_back.bytes()))
-  return b"".join([writer.bytes(), writer_header.bytes(),
-                   writer_front.bytes(), writer_back.bytes()])
+    writer = BitWriter()
+    writer.write_bytes(b"DF_LVL")
+    writer.write(16, 44)
+    writer.write(32, 12 + len(writer_header.bytes()) +
+                 len(writer_front.bytes()) +
+                 len(writer_back.bytes()))
+    return b"".join([writer.bytes(), writer_header.bytes(),
+                     writer_front.bytes(), writer_back.bytes()])

--- a/dustmaker/MapWriter.py
+++ b/dustmaker/MapWriter.py
@@ -1,13 +1,12 @@
-from .Map import Map
-from .Tile import Tile, TileSide, TileSpriteSet
-from .Prop import Prop
-from .Entity import Entity, Enemy
-from .Var import Var, VarType
-from .BitWriter import BitWriter
-from .MapException import MapParseException
-
 import zlib
 from math import floor
+
+
+from .Tile import TileSide, TileSpriteSet
+from .Entity import Enemy
+from .Var import VarType
+from .BitWriter import BitWriter
+from .MapException import MapParseException
 
 
 def _write_float(writer, ibits, fbits, val):
@@ -321,7 +320,7 @@ def write_map(map):
 
     writer_back = BitWriter()
     region_map = _compute_region_map(map)
-    for coord in sorted(region_map.keys(), key=_norm_for_sort):
+    for coord in sorted(region_map, key=_norm_for_sort):
         writer_back.align(8)
         writer_front.write(32, writer_back.byte_count())
         reg_data = _write_region(coord[0], coord[1], region_map[coord])

--- a/dustmaker/Prop.py
+++ b/dustmaker/Prop.py
@@ -2,7 +2,6 @@ import math
 
 
 class Prop:
-
     def __init__(self, layer_sub, rotation, scale_x, scale_y,
                  prop_set, prop_group, prop_index, palette):
         self.layer_sub = layer_sub

--- a/dustmaker/Prop.py
+++ b/dustmaker/Prop.py
@@ -1,22 +1,24 @@
 import math
 
+
 class Prop:
-  def __init__(self, layer_sub, rotation, scale_x, scale_y,
-               prop_set, prop_group, prop_index, palette):
-    self.layer_sub = layer_sub
-    self.rotation = rotation
-    self.scale_x = scale_x
-    self.scale_y = scale_y
-    self.prop_set = prop_set
-    self.prop_group = prop_group
-    self.prop_index = prop_index
-    self.palette = palette
 
-  def transform(self, mat):
-    angle = math.atan2(mat[1][1], mat[1][0]) - math.pi / 2
-    self.rotation = self.rotation - int(0x10000 * angle / math.pi / 2) & 0xFFFF
+    def __init__(self, layer_sub, rotation, scale_x, scale_y,
+                 prop_set, prop_group, prop_index, palette):
+        self.layer_sub = layer_sub
+        self.rotation = rotation
+        self.scale_x = scale_x
+        self.scale_y = scale_y
+        self.prop_set = prop_set
+        self.prop_group = prop_group
+        self.prop_index = prop_index
+        self.palette = palette
 
-    if mat[0][0] * mat[1][1] - mat[0][1] * mat[1][0] < 0:
-      self.scale_x = not self.scale_x
-      self.rotation = -self.rotation & 0xFFFF
+    def transform(self, mat):
+        angle = math.atan2(mat[1][1], mat[1][0]) - math.pi / 2
+        self.rotation = self.rotation - \
+            int(0x10000 * angle / math.pi / 2) & 0xFFFF
 
+        if mat[0][0] * mat[1][1] - mat[0][1] * mat[1][0] < 0:
+            self.scale_x = not self.scale_x
+            self.rotation = -self.rotation & 0xFFFF

--- a/dustmaker/Tile.py
+++ b/dustmaker/Tile.py
@@ -33,12 +33,14 @@ class TileShape(IntEnum):
 
         Big and small tiles form the inbetween angles.  The big tile variant
         covers 75% of the tile while the small tile variant covers 25% of the
-        tile.  Each of these comes in 8 varieties 1-8 depicted in the wheel below.
+        tile.  Each of these comes in 8 varieties 1-8 depicted in the wheel
+        below.
 
-        To determine the angle of a half, big, or small tile from its shape find
-        its identifier in the wheel.  Imagine you were located at X and the +
-        characters formed a circle around you; the angle of the tile would be
-        approximately the angle of the circle surface where its label is.::
+        To determine the angle of a half, big, or small tile from its shape
+        find its identifier in the wheel.  Imagine you were located at X and
+        the + characters formed a circle around you; the angle of the tile
+        would be approximately the angle of the circle surface where its label
+        is.::
 
                   +++++
                +7+     +3+
@@ -191,8 +193,8 @@ class Tile:
 
     def edge_bits(self, side, val=None):
         """ Returns the 4 bit number associated with `side` surface of the tile.
-            I'm unsure what each bit means currently.  Set all to 0 to freely move
-            through that side of the tile and to 0xF to cause collisions.
+            I'm unsure what each bit means currently.  Set all to 0 to freely
+            move through that side of the tile and to 0xF to cause collisions.
 
             side -- The side to get/set edge bits.
             val -- If present a 4 bit integer to set as the new edge bits.
@@ -202,7 +204,7 @@ class Tile:
         for (i, bit) in enumerate(bits):
             if self.tile_data[bit >> 3] & (1 << (bit & 7)):
                 result |= 1 << i
-            if not val is None:
+            if val is not None:
                 self.tile_data[bit >> 3] &= ~(1 << (bit & 7))
                 if val & 1 << i:
                     self.tile_data[bit >> 3] |= 1 << (bit & 7)
@@ -216,7 +218,7 @@ class Tile:
         """
         result = (self.tile_data[2 + side * 2] +
                   (self.tile_data[2 + side * 2 + 1] << 8))
-        if not val is None:
+        if val is not None:
             self.tile_data[2 + side * 2] = val & 0xFF
             self.tile_data[2 + side * 2 + 1] = val >> 8
         return result
@@ -227,7 +229,7 @@ class Tile:
             val -- If present a TileSpriteSet to set as the new sprite set.
         """
         result = TileSpriteSet(self.tile_data[10] & 0xF)
-        if not val is None:
+        if val is not None:
             self.tile_data[10] = (self.tile_data[10] & 0xF0) | val
         return result
 
@@ -237,7 +239,7 @@ class Tile:
             val -- If present the new tile index for this tile.
         """
         result = self.tile_data[11]
-        if not val is None:
+        if val is not None:
             self.tile_data[11] = val
         return result
 
@@ -247,7 +249,7 @@ class Tile:
             val -- If present the new palette index for this tile.
         """
         result = (self.tile_data[10] & 0xF0) >> 4
-        if not val is None:
+        if val is not None:
             self.tile_data[10] = (self.tile_data[10] & 0x0F) | (val << 4)
         return result
 
@@ -259,7 +261,8 @@ class Tile:
             val -- If present the new palette index for this tile.
         """
         return "area/%s/tiles/tile%d_%d_0001.png" % (
-            self.sprite_set().name, self.sprite_tile(), self.sprite_palette() + 1)
+            self.sprite_set().name, self.sprite_tile(),
+            self.sprite_palette() + 1)
 
     def has_filth(self):
         return self.dust_data[0] != 0 or self.dust_data[1] != 0
@@ -268,7 +271,7 @@ class Tile:
         ind = side // 2
         shft = 4 * (side % 2)
         result = (self.dust_data[ind] >> shft) & 0xF
-        if not sprite_set is None and not spikes is None:
+        if sprite_set is not None and spikes is not None:
             val = sprite_set | (0x8 if spikes else 0x0)
             self.dust_data[ind] &= 0xF0 >> shft
             self.dust_data[ind] |= val << shft
@@ -277,7 +280,7 @@ class Tile:
     def edge_filth_cap(self, side, val=None):
         shft = 2 * side
         result = (self.dust_data[10] >> shft) & 0x3
-        if not val is None:
+        if val is not None:
             self.dust_data[10] &= ~(0x3 << shft)
             self.dust_data[10] |= val << shft
         return result

--- a/dustmaker/Tile.py
+++ b/dustmaker/Tile.py
@@ -2,142 +2,146 @@ from enum import IntEnum
 
 import math
 
+
 class TileSpriteSet(IntEnum):
-  """ Used to describe what set of tiles a tile's sprite comes from. """
-  none_0 = 0
-  mansion = 1
-  forest = 2
-  city = 3
-  laboratory = 4
-  tutorial = 5
-  nexus = 6
-  none_7 = 7
+    """ Used to describe what set of tiles a tile's sprite comes from. """
+    none_0 = 0
+    mansion = 1
+    forest = 2
+    city = 3
+    laboratory = 4
+    tutorial = 5
+    nexus = 6
+    none_7 = 7
+
 
 class TileSide(IntEnum):
-  TOP = 0
-  BOTTOM = 1
-  LEFT = 2
-  RIGHT = 3
+    TOP = 0
+    BOTTOM = 1
+    LEFT = 2
+    RIGHT = 3
+
 
 class TileShape(IntEnum):
-  """ Tiles come in four main types; full, half, big, and small.
+    """ Tiles come in four main types; full, half, big, and small.
 
-      Full corresponds to a complete square tile.
+        Full corresponds to a complete square tile.
 
-      Half corresponds to one of the tiles aligned to 45 degrees that take up
-      half of the tile unit.  These come in four varieties A, B, C, and D
-      depicted on the wheel below.
+        Half corresponds to one of the tiles aligned to 45 degrees that take up
+        half of the tile unit.  These come in four varieties A, B, C, and D
+        depicted on the wheel below.
 
-      Big and small tiles form the inbetween angles.  The big tile variant
-      covers 75% of the tile while the small tile variant covers 25% of the
-      tile.  Each of these comes in 8 varieties 1-8 depicted in the wheel below.
+        Big and small tiles form the inbetween angles.  The big tile variant
+        covers 75% of the tile while the small tile variant covers 25% of the
+        tile.  Each of these comes in 8 varieties 1-8 depicted in the wheel below.
 
-      To determine the angle of a half, big, or small tile from its shape find
-      its identifier in the wheel.  Imagine you were located at X and the +
-      characters formed a circle around you; the angle of the tile would be
-      approximately the angle of the circle surface where its label is.::
+        To determine the angle of a half, big, or small tile from its shape find
+        its identifier in the wheel.  Imagine you were located at X and the +
+        characters formed a circle around you; the angle of the tile would be
+        approximately the angle of the circle surface where its label is.::
 
-                +++++
-             +7+     +3+
-            +           +
-           +             +
-          B               C
-         +                 +
-        +                   +
-        2                   6
-        +                   +
-       +                     +
-       +                     +
-       +          X          +
-       +                     +
-       +                     +
-        +                   +
-        8                   4
-        +                   +
-         +                 +
-          A               D
-           +             +
-            +           +
-             +1+     +5+
-                +++++
-  """
-  FULL = 0
-  BIG_1 = 1
-  SMALL_1 = 2
-  BIG_2 = 3
-  SMALL_2 = 4
-  BIG_3 = 5
-  SMALL_3 = 6
-  BIG_4 = 7
-  SMALL_4 = 8
-  BIG_5 = 9
-  SMALL_5 = 10
-  BIG_6 = 11
-  SMALL_6 = 12
-  BIG_7 = 13
-  SMALL_7 = 14
-  BIG_8 = 15
-  SMALL_8 = 16
-  HALF_A = 17
-  HALF_B = 18
-  HALF_C = 19
-  HALF_D = 20
+                  +++++
+               +7+     +3+
+              +           +
+             +             +
+            B               C
+           +                 +
+          +                   +
+          2                   6
+          +                   +
+         +                     +
+         +                     +
+         +          X          +
+         +                     +
+         +                     +
+          +                   +
+          8                   4
+          +                   +
+           +                 +
+            A               D
+             +             +
+              +           +
+               +1+     +5+
+                  +++++
+    """
+    FULL = 0
+    BIG_1 = 1
+    SMALL_1 = 2
+    BIG_2 = 3
+    SMALL_2 = 4
+    BIG_3 = 5
+    SMALL_3 = 6
+    BIG_4 = 7
+    SMALL_4 = 8
+    BIG_5 = 9
+    SMALL_5 = 10
+    BIG_6 = 11
+    SMALL_6 = 12
+    BIG_7 = 13
+    SMALL_7 = 14
+    BIG_8 = 15
+    SMALL_8 = 16
+    HALF_A = 17
+    HALF_B = 18
+    HALF_C = 19
+    HALF_D = 20
 
 tile_maximal_bits = [
-  [ 15, 15, 15, 15, ], # TileShape.FULL:
-  [ 7, 15, 15, 0, ], # TileShape.BIG_1:
-  [ 11, 15, 0, 0, ], # TileShape.SMALL_1:
-  [ 15, 0, 15, 7, ], # TileShape.BIG_2:
-  [ 0, 0, 15, 11, ], # TileShape.SMALL_2:
-  [ 15, 11, 0, 15, ], # TileShape.BIG_3:
-  [ 15, 7, 0, 0, ], # TileShape.SMALL_3:
-  [ 0, 15, 11, 15, ], # TileShape.BIG_4:
-  [ 0, 0, 7, 15, ], # TileShape.SMALL_4:
-  [ 11, 15, 0, 15, ], # TileShape.BIG_5:
-  [ 7, 15, 0, 0, ], # TileShape.SMALL_5:
-  [ 15, 0, 7, 15, ], # TileShape.BIG_6:
-  [ 0, 0, 11, 15, ], # TileShape.SMALL_6:
-  [ 15, 7, 15, 0, ], # TileShape.BIG_7:
-  [ 15, 11, 0, 0, ], # TileShape.SMALL_7:
-  [ 0, 15, 15, 11, ], # TileShape.BIG_8:
-  [ 0, 0, 15, 7, ], # TileShape.SMALL_8:
-  [ 15, 15, 15, 0, ], # TileShape.HALF_A:
-  [ 15, 15, 15, 0, ], # TileShape.HALF_B:
-  [ 15, 15, 0, 15, ], # TileShape.HALF_C:
-  [ 15, 15, 0, 15, ], # TileShape.HALF_D:
+    [15, 15, 15, 15, ],  # TileShape.FULL:
+    [7, 15, 15, 0, ],  # TileShape.BIG_1:
+    [11, 15, 0, 0, ],  # TileShape.SMALL_1:
+    [15, 0, 15, 7, ],  # TileShape.BIG_2:
+    [0, 0, 15, 11, ],  # TileShape.SMALL_2:
+    [15, 11, 0, 15, ],  # TileShape.BIG_3:
+    [15, 7, 0, 0, ],  # TileShape.SMALL_3:
+    [0, 15, 11, 15, ],  # TileShape.BIG_4:
+    [0, 0, 7, 15, ],  # TileShape.SMALL_4:
+    [11, 15, 0, 15, ],  # TileShape.BIG_5:
+    [7, 15, 0, 0, ],  # TileShape.SMALL_5:
+    [15, 0, 7, 15, ],  # TileShape.BIG_6:
+    [0, 0, 11, 15, ],  # TileShape.SMALL_6:
+    [15, 7, 15, 0, ],  # TileShape.BIG_7:
+    [15, 11, 0, 0, ],  # TileShape.SMALL_7:
+    [0, 15, 15, 11, ],  # TileShape.BIG_8:
+    [0, 0, 15, 7, ],  # TileShape.SMALL_8:
+    [15, 15, 15, 0, ],  # TileShape.HALF_A:
+    [15, 15, 15, 0, ],  # TileShape.HALF_B:
+    [15, 15, 0, 15, ],  # TileShape.HALF_C:
+    [15, 15, 0, 15, ],  # TileShape.HALF_D:
 ]
 
 # Full - Clockwise from top
 # Small/Big/Half - Clockwise from hyp. (ccw from mirrored)
 shape_ordered_sides = [
-  [0, 2, 1, 3],
-  [0, 1, 2],
-  [0, 1],
-  [3, 2, 0],
-  [3, 2],
-  [1, 0, 3],
-  [1, 0],
-  [2, 3, 1],
-  [2, 3],
-  [0, 1, 3],
-  [0, 1],
-  [2, 3, 0],
-  [2, 3],
-  [1, 0, 2],
-  [1, 0],
-  [3, 2, 1],
-  [3, 2],
-  [0, 1, 2],
-  [1, 2, 0],
-  [1, 0, 3],
-  [0, 3, 1],
+    [0, 2, 1, 3],
+    [0, 1, 2],
+    [0, 1],
+    [3, 2, 0],
+    [3, 2],
+    [1, 0, 3],
+    [1, 0],
+    [2, 3, 1],
+    [2, 3],
+    [0, 1, 3],
+    [0, 1],
+    [2, 3, 0],
+    [2, 3],
+    [1, 0, 2],
+    [1, 0],
+    [3, 2, 1],
+    [3, 2],
+    [0, 1, 2],
+    [1, 2, 0],
+    [1, 0, 3],
+    [0, 3, 1],
 ]
 
+
 class Tile:
-  """ Represents a single tile in a Dustforce level.  Positional information
-      is stored within Map.
-  """
-  """ Tile byte layout notes
+    """ Represents a single tile in a Dustforce level.  Positional information
+        is stored within Map.
+    """
+    """ Tile byte layout notes
         0x0 0,4 top
             1,5 bottom
             2,6 left
@@ -165,172 +169,171 @@ class Tile:
         5 -> Virtual
   """
 
-  def __init__(self, shape, _tile_data = None, _dust_data = None):
-    """ Initialize a vanilla virtual tile of the given shape. """
-    self.shape = shape
+    def __init__(self, shape, _tile_data=None, _dust_data=None):
+        """ Initialize a vanilla virtual tile of the given shape. """
+        self.shape = shape
 
-    if _tile_data is None:
-      self.tile_data = bytearray(12)
-      for side in TileSide:
-        self.edge_bits(side, tile_maximal_bits[shape][side])
-        self.edge_angle(side, 0)
-      self.sprite_set(TileSpriteSet.tutorial)
-      self.sprite_tile(1)
-      self.sprite_palette(0)
-    else:
-      self.tile_data = bytearray(_tile_data)
+        if _tile_data is None:
+            self.tile_data = bytearray(12)
+            for side in TileSide:
+                self.edge_bits(side, tile_maximal_bits[shape][side])
+                self.edge_angle(side, 0)
+            self.sprite_set(TileSpriteSet.tutorial)
+            self.sprite_tile(1)
+            self.sprite_palette(0)
+        else:
+            self.tile_data = bytearray(_tile_data)
 
-    if _dust_data is None:
-      self.dust_data = bytearray(12)
-    else:
-      self.dust_data = bytearray(_dust_data)
+        if _dust_data is None:
+            self.dust_data = bytearray(12)
+        else:
+            self.dust_data = bytearray(_dust_data)
 
-  def edge_bits(self, side, val = None):
-    """ Returns the 4 bit number associated with `side` surface of the tile.
-        I'm unsure what each bit means currently.  Set all to 0 to freely move
-        through that side of the tile and to 0xF to cause collisions.
+    def edge_bits(self, side, val=None):
+        """ Returns the 4 bit number associated with `side` surface of the tile.
+            I'm unsure what each bit means currently.  Set all to 0 to freely move
+            through that side of the tile and to 0xF to cause collisions.
 
-        side -- The side to get/set edge bits.
-        val -- If present a 4 bit integer to set as the new edge bits.
-    """
-    result = 0
-    bits = [0 + side, 4 + side, 8 + 2 * side, 9 + 2 * side]
-    for (i, bit) in enumerate(bits):
-      if self.tile_data[bit >> 3] & (1 << (bit & 7)):
-        result |= 1 << i
-      if not val is None:
-        self.tile_data[bit >> 3] &= ~(1 << (bit & 7))
-        if val & 1 << i:
-          self.tile_data[bit >> 3] |= 1 << (bit & 7)
-    return result
+            side -- The side to get/set edge bits.
+            val -- If present a 4 bit integer to set as the new edge bits.
+        """
+        result = 0
+        bits = [0 + side, 4 + side, 8 + 2 * side, 9 + 2 * side]
+        for (i, bit) in enumerate(bits):
+            if self.tile_data[bit >> 3] & (1 << (bit & 7)):
+                result |= 1 << i
+            if not val is None:
+                self.tile_data[bit >> 3] &= ~(1 << (bit & 7))
+                if val & 1 << i:
+                    self.tile_data[bit >> 3] |= 1 << (bit & 7)
+        return result
 
-  def edge_angle(self, side, val = None):
-    """ Returns the angle of `side` as a 16 bit integer.
+    def edge_angle(self, side, val=None):
+        """ Returns the angle of `side` as a 16 bit integer.
 
-        side -- The side to get/set edge angle.
-        val -- If present a 16 bit integer to set as the new edge angle.
-    """
-    result = (self.tile_data[2 + side * 2] +
-              (self.tile_data[2 + side * 2 + 1] << 8))
-    if not val is None:
-      self.tile_data[2 + side * 2] = val & 0xFF
-      self.tile_data[2 + side * 2 + 1] = val >> 8
-    return result
+            side -- The side to get/set edge angle.
+            val -- If present a 16 bit integer to set as the new edge angle.
+        """
+        result = (self.tile_data[2 + side * 2] +
+                  (self.tile_data[2 + side * 2 + 1] << 8))
+        if not val is None:
+            self.tile_data[2 + side * 2] = val & 0xFF
+            self.tile_data[2 + side * 2 + 1] = val >> 8
+        return result
 
-  def sprite_set(self, val = None):
-    """ Returns the sprite set from TileSpriteSet associated with this tile.
+    def sprite_set(self, val=None):
+        """ Returns the sprite set from TileSpriteSet associated with this tile.
 
-        val -- If present a TileSpriteSet to set as the new sprite set.
-    """
-    result = TileSpriteSet(self.tile_data[10] & 0xF)
-    if not val is None:
-      self.tile_data[10] = (self.tile_data[10] & 0xF0) | val
-    return result
+            val -- If present a TileSpriteSet to set as the new sprite set.
+        """
+        result = TileSpriteSet(self.tile_data[10] & 0xF)
+        if not val is None:
+            self.tile_data[10] = (self.tile_data[10] & 0xF0) | val
+        return result
 
-  def sprite_tile(self, val = None):
-    """ Returns the tile index associated with this tile.
+    def sprite_tile(self, val=None):
+        """ Returns the tile index associated with this tile.
 
-        val -- If present the new tile index for this tile.
-    """
-    result = self.tile_data[11]
-    if not val is None:
-      self.tile_data[11] = val
-    return result
+            val -- If present the new tile index for this tile.
+        """
+        result = self.tile_data[11]
+        if not val is None:
+            self.tile_data[11] = val
+        return result
 
-  def sprite_palette(self, val = None):
-    """ Returns the palette index associated with this tile.
+    def sprite_palette(self, val=None):
+        """ Returns the palette index associated with this tile.
 
-        val -- If present the new palette index for this tile.
-    """
-    result = (self.tile_data[10] & 0xF0) >> 4
-    if not val is None:
-      self.tile_data[10] = (self.tile_data[10] & 0x0F) | (val << 4)
-    return result
+            val -- If present the new palette index for this tile.
+        """
+        result = (self.tile_data[10] & 0xF0) >> 4
+        if not val is None:
+            self.tile_data[10] = (self.tile_data[10] & 0x0F) | (val << 4)
+        return result
 
-  def sprite_path(self):
-    """ Returns the palette index associated with this tile.  You may
-        retrieve the complete game sprites listing from
-        https://www.dropbox.com/s/jm37ew9p74olgca/sprites.zip?dl=0
+    def sprite_path(self):
+        """ Returns the palette index associated with this tile.  You may
+            retrieve the complete game sprites listing from
+            https://www.dropbox.com/s/jm37ew9p74olgca/sprites.zip?dl=0
 
-        val -- If present the new palette index for this tile.
-    """
-    return "area/%s/tiles/tile%d_%d_0001.png" % (
-        self.sprite_set().name, self.sprite_tile(), self.sprite_palette() + 1)
+            val -- If present the new palette index for this tile.
+        """
+        return "area/%s/tiles/tile%d_%d_0001.png" % (
+            self.sprite_set().name, self.sprite_tile(), self.sprite_palette() + 1)
 
+    def has_filth(self):
+        return self.dust_data[0] != 0 or self.dust_data[1] != 0
 
-  def has_filth(self):
-    return self.dust_data[0] != 0 or self.dust_data[1] != 0
+    def edge_filth_sprite(self, side, sprite_set=None, spikes=None):
+        ind = side // 2
+        shft = 4 * (side % 2)
+        result = (self.dust_data[ind] >> shft) & 0xF
+        if not sprite_set is None and not spikes is None:
+            val = sprite_set | (0x8 if spikes else 0x0)
+            self.dust_data[ind] &= 0xF0 >> shft
+            self.dust_data[ind] |= val << shft
+        return (TileSpriteSet(result & 0x7), (result & 0x8) != 0)
 
-  def edge_filth_sprite(self, side, sprite_set = None, spikes = None):
-    ind = side // 2
-    shft = 4 * (side % 2)
-    result = (self.dust_data[ind] >> shft) & 0xF
-    if not sprite_set is None and not spikes is None:
-      val = sprite_set | (0x8 if spikes else 0x0)
-      self.dust_data[ind] &= 0xF0 >> shft
-      self.dust_data[ind] |= val << shft
-    return (TileSpriteSet(result & 0x7), (result & 0x8) != 0)
+    def edge_filth_cap(self, side, val=None):
+        shft = 2 * side
+        result = (self.dust_data[10] >> shft) & 0x3
+        if not val is None:
+            self.dust_data[10] &= ~(0x3 << shft)
+            self.dust_data[10] |= val << shft
+        return result
 
-  def edge_filth_cap(self, side, val = None):
-    shft = 2 * side
-    result = (self.dust_data[10] >> shft) & 0x3
-    if not val is None:
-      self.dust_data[10] &= ~(0x3 << shft)
-      self.dust_data[10] |= val << shft
-    return result
+    def is_dustblock(self):
+        dustblocks = {
+            TileSpriteSet.mansion: 21,
+            TileSpriteSet.forest: 13,
+            TileSpriteSet.city: 6,
+            TileSpriteSet.laboratory: 9,
+            TileSpriteSet.tutorial: 2,
+        }
+        st = self.sprite_set()
+        tl = self.sprite_tile()
+        return dustblocks.get(st, -1) == tl
 
-  def is_dustblock(self):
-    dustblocks = {
-      TileSpriteSet.mansion: 21,
-      TileSpriteSet.forest: 13,
-      TileSpriteSet.city: 6,
-      TileSpriteSet.laboratory: 9,
-      TileSpriteSet.tutorial: 2,
-    }
-    st = self.sprite_set()
-    tl = self.sprite_tile()
-    return dustblocks.get(st, -1) == tl
+    def transform(self, mat):
+        global shape_ordered_sides
 
-  def transform(self, mat):
-    global shape_ordered_sides
-
-    oshape = self.shape
-    flipped = mat[0][0] * mat[1][1] - mat[0][1] * mat[1][0] < 0
-    if flipped:
-      if self.shape == TileShape.FULL:
-        pass
-      elif self.shape <= TileShape.SMALL_8:
-        self.shape = 1 + ((self.shape - TileShape.BIG_1) ^ 8) % 16
-      else:
-        self.shape = 17 + ((self.shape - TileShape.HALF_A) ^ 3)
-    angle = int(round(math.atan2(mat[1][1], mat[1][0]) / math.pi * 2))
-    angle = (-angle + 1) & 0x3
-
-    if self.shape == TileShape.FULL:
-      pass
-    elif self.shape <= TileShape.SMALL_4:
-      self.shape = 1 + ((self.shape - TileShape.BIG_1) + angle * 2) % 8
-    elif self.shape <= TileShape.SMALL_8:
-      self.shape = 9 + ((self.shape - TileShape.BIG_5) - angle * 2) % 8
-    else:
-      self.shape = 17 + ((self.shape - TileShape.HALF_A) + angle) % 4
-
-    nbits = []
-    nfilth_sprite = []
-    nfilth_cap = []
-    for side in shape_ordered_sides[oshape]:
-      nbits.append(self.edge_bits(side))
-      nfilth_sprite.append(self.edge_filth_sprite(side))
-      nfilth_cap.append(self.edge_filth_cap(side))
-    for side in TileSide:
-      self.edge_bits(side, 0)
-      self.edge_filth_sprite(side, TileSpriteSet.none_0, False)
-      self.edge_filth_cap(side, 0)
-    for (i, side) in enumerate(shape_ordered_sides[self.shape]):
-      if self.shape == TileShape.FULL:
-        i = i + angle & 3
+        oshape = self.shape
+        flipped = mat[0][0] * mat[1][1] - mat[0][1] * mat[1][0] < 0
         if flipped:
-          i = -i & 3
-      self.edge_bits(side, nbits[i])
-      self.edge_filth_sprite(side, *nfilth_sprite[i])
-      self.edge_filth_cap(side, nfilth_cap[i])
+            if self.shape == TileShape.FULL:
+                pass
+            elif self.shape <= TileShape.SMALL_8:
+                self.shape = 1 + ((self.shape - TileShape.BIG_1) ^ 8) % 16
+            else:
+                self.shape = 17 + ((self.shape - TileShape.HALF_A) ^ 3)
+        angle = int(round(math.atan2(mat[1][1], mat[1][0]) / math.pi * 2))
+        angle = (-angle + 1) & 0x3
+
+        if self.shape == TileShape.FULL:
+            pass
+        elif self.shape <= TileShape.SMALL_4:
+            self.shape = 1 + ((self.shape - TileShape.BIG_1) + angle * 2) % 8
+        elif self.shape <= TileShape.SMALL_8:
+            self.shape = 9 + ((self.shape - TileShape.BIG_5) - angle * 2) % 8
+        else:
+            self.shape = 17 + ((self.shape - TileShape.HALF_A) + angle) % 4
+
+        nbits = []
+        nfilth_sprite = []
+        nfilth_cap = []
+        for side in shape_ordered_sides[oshape]:
+            nbits.append(self.edge_bits(side))
+            nfilth_sprite.append(self.edge_filth_sprite(side))
+            nfilth_cap.append(self.edge_filth_cap(side))
+        for side in TileSide:
+            self.edge_bits(side, 0)
+            self.edge_filth_sprite(side, TileSpriteSet.none_0, False)
+            self.edge_filth_cap(side, 0)
+        for (i, side) in enumerate(shape_ordered_sides[self.shape]):
+            if self.shape == TileShape.FULL:
+                i = i + angle & 3
+                if flipped:
+                    i = -i & 3
+            self.edge_bits(side, nbits[i])
+            self.edge_filth_sprite(side, *nfilth_sprite[i])
+            self.edge_filth_cap(side, nfilth_cap[i])

--- a/dustmaker/Var.py
+++ b/dustmaker/Var.py
@@ -1,19 +1,22 @@
 from enum import IntEnum
 
+
 class VarType(IntEnum):
-  NULL = 0
-  BOOL = 1
-  UINT = 2
-  INT = 3
-  FLOAT = 4
-  STRING = 5
-  VEC2 = 10
-  ARRAY = 15
+    NULL = 0
+    BOOL = 1
+    UINT = 2
+    INT = 3
+    FLOAT = 4
+    STRING = 5
+    VEC2 = 10
+    ARRAY = 15
+
 
 class Var:
-  def __init__(self, type, value):
-    self.type = type
-    self.value = value
 
-  def __repr__(self):
-    return "Var (%s, %s)" % (repr(self.type), repr(self.value))
+    def __init__(self, type, value):
+        self.type = type
+        self.value = value
+
+    def __repr__(self):
+        return "Var (%s, %s)" % (repr(self.type), repr(self.value))

--- a/dustmaker/Var.py
+++ b/dustmaker/Var.py
@@ -13,7 +13,6 @@ class VarType(IntEnum):
 
 
 class Var:
-
     def __init__(self, type, value):
         self.type = type
         self.value = value

--- a/dustmaker/__init__.py
+++ b/dustmaker/__init__.py
@@ -1,9 +1,11 @@
+"""A library for reading and manipulating Dustforce level files"""
 from .Map import Map
-from .Entity import Entity, AIController, CameraNode, LevelEnd, Enemy, DeathZone
-from .Prop import Prop
-from .Var import Var, VarType
 from .MapException import MapException, MapParseException
-from .Tile import Tile, TileShape, TileSpriteSet, TileSide
+from .Prop import Prop
+from .Tile import Tile, TileSide, TileShape, TileSpriteSet
+from .Var import Var, VarType
+from .Entity import \
+    AIController, CameraNode, DeathZone, Enemy, Entity, LevelEnd
 
 from .MapReader import read_map
 from .MapWriter import write_map


### PR DESCRIPTION
I ran the module through autopep8 and made a few manual edits to remove a bunch of linter errors. This makes the module conform to the PEP8 standard a bit more and uses 4-space tabs instead of 2, assuming that that's okay.
